### PR TITLE
fix DistinctBy and Prepend

### DIFF
--- a/src/R3/Operators/AppendPrepend.cs
+++ b/src/R3/Operators/AppendPrepend.cs
@@ -21,6 +21,7 @@ internal sealed class AppendPrepend<T>(Observable<T> source, T value, bool appen
         if (!append) // prepend
         {
             observer.OnNext(value);
+            return source.Subscribe(observer.Wrap());
         }
 
         return source.Subscribe(new _Append(observer, value));

--- a/src/R3/Operators/Distinct.cs
+++ b/src/R3/Operators/Distinct.cs
@@ -14,7 +14,7 @@ public static partial class ObservableExtensions
 
     public static Observable<TSource> DistinctBy<TSource, TKey>(this Observable<TSource> source, Func<TSource, TKey> keySelector)
     {
-        return DistinctBy(source, keySelector);
+        return DistinctBy(source, keySelector, EqualityComparer<TKey>.Default);
     }
 
     public static Observable<TSource> DistinctBy<TSource, TKey>(this Observable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)

--- a/tests/R3.Tests/OperatorTests/ConcatAppendPrependTest.cs
+++ b/tests/R3.Tests/OperatorTests/ConcatAppendPrependTest.cs
@@ -16,6 +16,14 @@ public class ConcatAppendPrependTest
         list.AssertIsCompleted();
     }
 
+    [Fact(Skip = "test fails.")]
+    public void Prepend2()
+    {
+        using var list = Observable.Range(1, 3).Prepend(9999).ToLiveList();
+
+        list.AssertEqual([9999, 1, 2, 3]);
+    }
+
     [Fact]
     public void Append()
     {

--- a/tests/R3.Tests/OperatorTests/ConcatAppendPrependTest.cs
+++ b/tests/R3.Tests/OperatorTests/ConcatAppendPrependTest.cs
@@ -16,7 +16,7 @@ public class ConcatAppendPrependTest
         list.AssertIsCompleted();
     }
 
-    [Fact(Skip = "test fails.")]
+    [Fact]
     public void Prepend2()
     {
         using var list = Observable.Range(1, 3).Prepend(9999).ToLiveList();

--- a/tests/R3.Tests/OperatorTests/DefaultIfEmptyTest.cs
+++ b/tests/R3.Tests/OperatorTests/DefaultIfEmptyTest.cs
@@ -1,0 +1,12 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class DefaultIfEmptyTest
+{
+    [Fact]
+    public void DefaultIfEmpty()
+    {
+        using var list = Observable.Empty<int>().DefaultIfEmpty().ToLiveList();
+
+        list.AssertEqual([0]);
+    }
+}

--- a/tests/R3.Tests/OperatorTests/DistinctByTest.cs
+++ b/tests/R3.Tests/OperatorTests/DistinctByTest.cs
@@ -1,0 +1,28 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class DistinctByTest
+{
+    [Fact]
+    public void DistinctBy()
+    {
+        var source = new Subject<(int, int)>();
+
+        using var list = source.DistinctBy(static x => x.Item1).ToLiveList();
+
+        source.OnNext((1, 10));
+        source.OnNext((2, 20));
+        source.OnNext((3, 30));
+        source.OnNext((1, 100));
+        source.OnNext((2, 200));
+        source.OnNext((3, 300));
+        source.OnNext((4, 400));
+
+        list.AssertEqual(
+            [
+                (1, 10),
+                (2, 20),
+                (3, 30),
+                (4, 400)
+            ]);
+    }
+}

--- a/tests/R3.Tests/OperatorTests/DistinctTest.cs
+++ b/tests/R3.Tests/OperatorTests/DistinctTest.cs
@@ -1,0 +1,22 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class DistinctTest
+{
+    [Fact]
+    public void Distinct()
+    {
+        var source = new Subject<int>();
+
+        using var list = source.Distinct().ToLiveList();
+
+        source.OnNext(1);
+        source.OnNext(2);
+        source.OnNext(3);
+        source.OnNext(1);
+        source.OnNext(2);
+        source.OnNext(3);
+        source.OnNext(4);
+
+        list.AssertEqual([1, 2, 3, 4]);
+    }
+}

--- a/tests/R3.Tests/OperatorTests/DistinctUntilChangedByTest.cs
+++ b/tests/R3.Tests/OperatorTests/DistinctUntilChangedByTest.cs
@@ -1,0 +1,28 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class DistinctUntilChangedByTest
+{
+    [Fact]
+    public void DistinctUntilChangedBy()
+    {
+        var source = new Subject<(int, int)>();
+
+        using var list = source.DistinctUntilChangedBy(static x => x.Item1).ToLiveList();
+
+        source.OnNext((1, 10));
+        source.OnNext((2, 20));
+        source.OnNext((3, 30));
+        source.OnNext((3, 300));
+        source.OnNext((2, 200));
+        source.OnNext((1, 100));
+
+        list.AssertEqual(
+            [
+                (1, 10),
+                (2, 20),
+                (3, 30),
+                (2, 200),
+                (1, 100)
+            ]);
+    }
+}

--- a/tests/R3.Tests/OperatorTests/DistinctUntilChangedTest.cs
+++ b/tests/R3.Tests/OperatorTests/DistinctUntilChangedTest.cs
@@ -1,0 +1,21 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class DistinctUntilChangedTest
+{
+    [Fact]
+    public void DistinctUntilChanged()
+    {
+        var source = new Subject<int>();
+
+        using var list = source.DistinctUntilChanged().ToLiveList();
+
+        source.OnNext(1);
+        source.OnNext(2);
+        source.OnNext(3);
+        source.OnNext(3);
+        source.OnNext(2);
+        source.OnNext(1);
+
+        list.AssertEqual([1, 2, 3, 2, 1]);
+    }
+}

--- a/tests/R3.Tests/OperatorTests/PairwiseTest.cs
+++ b/tests/R3.Tests/OperatorTests/PairwiseTest.cs
@@ -1,0 +1,16 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class PairwiseTest
+{
+    [Fact]
+    public void Pairwise()
+    {
+        using var list = Observable.Range(1, 3).Pairwise().ToLiveList();
+
+        list.AssertEqual(
+            [
+                (1, 2),
+                (2, 3)
+            ]);
+    }
+}

--- a/tests/R3.Tests/OperatorTests/ScanTest.cs
+++ b/tests/R3.Tests/OperatorTests/ScanTest.cs
@@ -1,0 +1,26 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class ScanTest
+{
+    [Fact]
+    public void Scan()
+    {
+        using var list = Observable
+            .Range(1, 3)
+            .Scan(static (first, second) => first + second)
+            .ToLiveList();
+
+        list.AssertEqual([ 1, 3, 6 ]);
+    }
+
+    [Fact]
+    public void ScanWithSeed()
+    {
+        using var list = Observable
+            .Range(1, 3)
+            .Scan(1, static (first, second) => first + second)
+            .ToLiveList();
+
+        list.AssertEqual([ 2, 4, 7]);
+    }
+}

--- a/tests/R3.Tests/OperatorTests/SwitchTest.cs
+++ b/tests/R3.Tests/OperatorTests/SwitchTest.cs
@@ -1,0 +1,39 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class SwitchTest
+{
+    [Fact]
+    public void Switch()
+    {
+        var sources = new Subject<Observable<int>>();
+
+        using var list = sources.Switch().ToLiveList();
+
+        var source1 = new Subject<int>();
+        var source2 = new Subject<int>();
+
+        sources.OnNext(source1);
+
+        list.AssertEmpty();
+
+        source1.OnNext(1);
+        source1.OnNext(2);
+
+        sources.OnNext(source2);
+
+        source2.OnNext(10);
+
+        source1.OnNext(3);
+
+        list.AssertEqual([1, 2, 10]);
+
+        source1.OnCompleted();
+        source2.OnCompleted();
+
+        list.AssertIsNotCompleted();
+
+        sources.OnCompleted();
+
+        list.AssertIsCompleted();
+    }
+}


### PR DESCRIPTION
Added tests for following operators:

- `DefaultIfEmpty`
- `DistinctBy`
- `Distinct`
- `DistinctUntilChanged`
- `DistinctUntilChangedBy`
- `Pairwise`
- `Prepend`
- `Scan`
- `Switch`