### PR TITLE
Warning in ReadOnlyReactiveProperty.ToReadOnlyReactiveProperty

### DIFF
--- a/src/R3/ReactiveProperty.cs
+++ b/src/R3/ReactiveProperty.cs
@@ -3,6 +3,7 @@
 public abstract class ReadOnlyReactiveProperty<T> : Observable<T>
 {
     public abstract T CurrentValue { get; }
+    public ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty() => this;
 }
 
 // almostly same code as Subject<T>.


### PR DESCRIPTION
 Warning occurs in this code.
CS8620, differences in the nullability.

```cs
new ReactiveProperty<string>("foo").ToReadOnlyReactiveProperty();
```

The cause of this is the default parameter of ReactivePropertyExtensions.ToReadOnlyReactiveProperty, "(T initialValue = default(T))".
