### PR TITLE
Add independent implementations of Sum, with some overloads

### DIFF
--- a/src/R3/Operators/AggregateOperators.cs
+++ b/src/R3/Operators/AggregateOperators.cs
@@ -103,12 +103,6 @@ public static partial class ObservableExtensions
 
 #if NET8_0_OR_GREATER
 
-    public static Task<T> SumAsync<T>(this Observable<T> source, CancellationToken cancellationToken = default)
-        where T : IAdditionOperators<T, T, T>
-    {
-        return AggregateAsync(source, default(T)!, static (sum, message) => checked(sum + message), Stubs<T>.ReturnSelf, cancellationToken); // ignore complete
-    }
-
     public static Task<double> AverageAsync<T>(this Observable<T> source, CancellationToken cancellationToken = default)
         where T : INumberBase<T>
     {
@@ -133,3 +127,5 @@ public static partial class ObservableExtensions
         return AggregateAsync(source, 0, static (_, _) => 0, Stubs<int>.ReturnSelf, cancellationToken);
     }
 }
+
+

--- a/src/R3/Operators/SumAsync.cs
+++ b/src/R3/Operators/SumAsync.cs
@@ -1,0 +1,553 @@
+﻿
+namespace R3;
+
+using System.Numerics;
+
+public static partial class ObservableExtensions
+{
+    public static Task<int> SumAsync(this Observable<int> source, CancellationToken cancellationToken = default)
+    {
+        var method = new SumInt32Async(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<int> SumAsync<TSource>(this Observable<TSource> source, Func<TSource, int> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new SumInt32Async<TSource>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<long> SumAsync(this Observable<long> source, CancellationToken cancellationToken = default)
+    {
+        var method = new SumInt64Async(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<long> SumAsync<TSource>(this Observable<TSource> source, Func<TSource, long> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new SumInt64Async<TSource>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<float> SumAsync(this Observable<float> source, CancellationToken cancellationToken = default)
+    {
+        var method = new SumFloatAsync(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<float> SumAsync<TSource>(this Observable<TSource> source, Func<TSource, float> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new SumFloatAsync<TSource>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> SumAsync(this Observable<double> source, CancellationToken cancellationToken = default)
+    {
+        var method = new SumDoubleAsync(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> SumAsync<TSource>(this Observable<TSource> source, Func<TSource, double> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new SumDoubleAsync<TSource>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<decimal> SumAsync(this Observable<decimal> source, CancellationToken cancellationToken = default)
+    {
+        var method = new SumDecimalAsync(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<decimal> SumAsync<TSource>(this Observable<TSource> source, Func<TSource, decimal> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new SumDecimalAsync<TSource>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+
+#if NET8_0_OR_GREATER
+    public static Task<T> SumAsync<T>(this Observable<T> source, CancellationToken cancellationToken = default)
+        where T : IAdditionOperators<T, T, T>
+    {
+        var method = new SumNumberAsync<T>(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<TResult> SumAsync<TSource, TResult>(this Observable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken = default)
+        where TResult : IAdditionOperators<TResult, TResult, TResult>
+    {
+        var method = new SumNumberAsync<TSource, TResult>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+#endif
+}
+
+internal sealed class SumInt32Async(CancellationToken cancellationToken) : TaskObserverBase<int, int>(cancellationToken)
+{
+    int sum;
+    bool hasValue;
+
+    protected override void OnNextCore(int value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumInt32Async<TSource>(Func<TSource, int> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, int>(cancellationToken)
+{
+    int sum;
+    bool hasValue;
+
+    protected override void OnNextCore(TSource value)
+    {
+        hasValue = true;
+        sum += selector(value);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+internal sealed class SumInt64Async(CancellationToken cancellationToken) : TaskObserverBase<long, long>(cancellationToken)
+{
+    long sum;
+    bool hasValue;
+
+    protected override void OnNextCore(long value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumInt64Async<TSource>(Func<TSource, long> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, long>(cancellationToken)
+{
+    long sum;
+    bool hasValue;
+
+    protected override void OnNextCore(TSource value)
+    {
+        hasValue = true;
+        sum += selector(value);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+internal sealed class SumFloatAsync(CancellationToken cancellationToken) : TaskObserverBase<float, float>(cancellationToken)
+{
+    float sum;
+    bool hasValue;
+
+    protected override void OnNextCore(float value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumFloatAsync<TSource>(Func<TSource, float> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, float>(cancellationToken)
+{
+    float sum;
+    bool hasValue;
+
+    protected override void OnNextCore(TSource value)
+    {
+        hasValue = true;
+        sum += selector(value);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+internal sealed class SumDoubleAsync(CancellationToken cancellationToken) : TaskObserverBase<double, double>(cancellationToken)
+{
+    double sum;
+    bool hasValue;
+
+    protected override void OnNextCore(double value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumDoubleAsync<TSource>(Func<TSource, double> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+{
+    double sum;
+    bool hasValue;
+
+    protected override void OnNextCore(TSource value)
+    {
+        hasValue = true;
+        sum += selector(value);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+internal sealed class SumDecimalAsync(CancellationToken cancellationToken) : TaskObserverBase<decimal, decimal>(cancellationToken)
+{
+    decimal sum;
+    bool hasValue;
+
+    protected override void OnNextCore(decimal value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumDecimalAsync<TSource>(Func<TSource, decimal> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, decimal>(cancellationToken)
+{
+    decimal sum;
+    bool hasValue;
+
+    protected override void OnNextCore(TSource value)
+    {
+        hasValue = true;
+        sum += selector(value);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+
+#if NET8_0_OR_GREATER
+internal sealed class SumNumber<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
+    where T : IAdditionOperators<T, T, T>
+{
+    T sum = default!;
+    bool hasValue;
+
+    protected override void OnNextCore(T value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
+    where T : IAdditionOperators<T, T, T>
+{
+    T sum = default!;
+    bool hasValue;
+
+    protected override void OnNextCore(T value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumNumberAsync<TSource, TResult>(Func<TSource, TResult> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, TResult>(cancellationToken)
+    where TResult : IAdditionOperators<TResult, TResult, TResult>
+{
+    TResult sum;
+    bool hasValue;
+
+    protected override void OnNextCore(TSource value)
+    {
+        hasValue = true;
+        sum += selector(value);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+#endif

--- a/src/R3/Operators/SumAsync.cs
+++ b/src/R3/Operators/SumAsync.cs
@@ -98,11 +98,9 @@ public static partial class ObservableExtensions
 internal sealed class SumInt32Async(CancellationToken cancellationToken) : TaskObserverBase<int, int>(cancellationToken)
 {
     int sum;
-    bool hasValue;
 
     protected override void OnNextCore(int value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -118,15 +116,7 @@ internal sealed class SumInt32Async(CancellationToken cancellationToken) : TaskO
             TrySetException(result.Exception);
             return;
         }
-
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -154,24 +144,15 @@ internal sealed class SumInt32Async<TSource>(Func<TSource, int> selector, Cancel
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 internal sealed class SumInt64Async(CancellationToken cancellationToken) : TaskObserverBase<long, long>(cancellationToken)
 {
     long sum;
-    bool hasValue;
 
     protected override void OnNextCore(long value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -187,15 +168,7 @@ internal sealed class SumInt64Async(CancellationToken cancellationToken) : TaskO
             TrySetException(result.Exception);
             return;
         }
-
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -223,24 +196,15 @@ internal sealed class SumInt64Async<TSource>(Func<TSource, long> selector, Cance
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 internal sealed class SumFloatAsync(CancellationToken cancellationToken) : TaskObserverBase<float, float>(cancellationToken)
 {
     float sum;
-    bool hasValue;
 
     protected override void OnNextCore(float value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -256,15 +220,7 @@ internal sealed class SumFloatAsync(CancellationToken cancellationToken) : TaskO
             TrySetException(result.Exception);
             return;
         }
-
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -292,24 +248,15 @@ internal sealed class SumFloatAsync<TSource>(Func<TSource, float> selector, Canc
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 internal sealed class SumDoubleAsync(CancellationToken cancellationToken) : TaskObserverBase<double, double>(cancellationToken)
 {
     double sum;
-    bool hasValue;
 
     protected override void OnNextCore(double value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -325,15 +272,7 @@ internal sealed class SumDoubleAsync(CancellationToken cancellationToken) : Task
             TrySetException(result.Exception);
             return;
         }
-
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -361,24 +300,15 @@ internal sealed class SumDoubleAsync<TSource>(Func<TSource, double> selector, Ca
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 internal sealed class SumDecimalAsync(CancellationToken cancellationToken) : TaskObserverBase<decimal, decimal>(cancellationToken)
 {
     decimal sum;
-    bool hasValue;
 
     protected override void OnNextCore(decimal value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -394,15 +324,7 @@ internal sealed class SumDecimalAsync(CancellationToken cancellationToken) : Tas
             TrySetException(result.Exception);
             return;
         }
-
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -430,28 +352,18 @@ internal sealed class SumDecimalAsync<TSource>(Func<TSource, decimal> selector, 
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
-
 
 #if NET8_0_OR_GREATER
 internal sealed class SumNumber<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
     where T : IAdditionOperators<T, T, T>
 {
-    T sum = default!;
-    bool hasValue;
+    T sum;
 
     protected override void OnNextCore(T value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -468,26 +380,17 @@ internal sealed class SumNumber<T>(CancellationToken cancellationToken) : TaskOb
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
 internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
     where T : IAdditionOperators<T, T, T>
 {
-    T sum = default!;
-    bool hasValue;
+    T sum;
 
     protected override void OnNextCore(T value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -504,14 +407,7 @@ internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : T
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -519,11 +415,9 @@ internal sealed class SumNumberAsync<TSource, TResult>(Func<TSource, TResult> se
     where TResult : IAdditionOperators<TResult, TResult, TResult>
 {
     TResult sum;
-    bool hasValue;
 
     protected override void OnNextCore(TSource value)
     {
-        hasValue = true;
         sum += selector(value);
     }
 
@@ -540,14 +434,7 @@ internal sealed class SumNumberAsync<TSource, TResult>(Func<TSource, TResult> se
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 #endif

--- a/src/R3/Operators/SumAsync.cs
+++ b/src/R3/Operators/SumAsync.cs
@@ -101,7 +101,7 @@ internal sealed class SumInt32Async(CancellationToken cancellationToken) : TaskO
 
     protected override void OnNextCore(int value)
     {
-        sum += value;
+        sum = checked(sum + value);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -123,12 +123,11 @@ internal sealed class SumInt32Async(CancellationToken cancellationToken) : TaskO
 internal sealed class SumInt32Async<TSource>(Func<TSource, int> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, int>(cancellationToken)
 {
     int sum;
-    bool hasValue;
 
     protected override void OnNextCore(TSource value)
     {
-        hasValue = true;
-        sum += selector(value);
+        var add = selector(value);
+        sum = checked(sum + add);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -153,7 +152,7 @@ internal sealed class SumInt64Async(CancellationToken cancellationToken) : TaskO
 
     protected override void OnNextCore(long value)
     {
-        sum += value;
+        sum = checked(sum + value);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -175,12 +174,11 @@ internal sealed class SumInt64Async(CancellationToken cancellationToken) : TaskO
 internal sealed class SumInt64Async<TSource>(Func<TSource, long> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, long>(cancellationToken)
 {
     long sum;
-    bool hasValue;
 
     protected override void OnNextCore(TSource value)
     {
-        hasValue = true;
-        sum += selector(value);
+        var add = selector(value);
+        sum = checked(sum + add);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -205,7 +203,7 @@ internal sealed class SumFloatAsync(CancellationToken cancellationToken) : TaskO
 
     protected override void OnNextCore(float value)
     {
-        sum += value;
+        sum = checked(sum + value);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -227,12 +225,11 @@ internal sealed class SumFloatAsync(CancellationToken cancellationToken) : TaskO
 internal sealed class SumFloatAsync<TSource>(Func<TSource, float> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, float>(cancellationToken)
 {
     float sum;
-    bool hasValue;
 
     protected override void OnNextCore(TSource value)
     {
-        hasValue = true;
-        sum += selector(value);
+        var add = selector(value);
+        sum = checked(sum + add);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -257,7 +254,7 @@ internal sealed class SumDoubleAsync(CancellationToken cancellationToken) : Task
 
     protected override void OnNextCore(double value)
     {
-        sum += value;
+        sum = checked(sum + value);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -279,12 +276,11 @@ internal sealed class SumDoubleAsync(CancellationToken cancellationToken) : Task
 internal sealed class SumDoubleAsync<TSource>(Func<TSource, double> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
 {
     double sum;
-    bool hasValue;
 
     protected override void OnNextCore(TSource value)
     {
-        hasValue = true;
-        sum += selector(value);
+        var add = selector(value);
+        sum = checked(sum + add);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -309,7 +305,7 @@ internal sealed class SumDecimalAsync(CancellationToken cancellationToken) : Tas
 
     protected override void OnNextCore(decimal value)
     {
-        sum += value;
+        sum = checked(sum + value);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -331,12 +327,11 @@ internal sealed class SumDecimalAsync(CancellationToken cancellationToken) : Tas
 internal sealed class SumDecimalAsync<TSource>(Func<TSource, decimal> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, decimal>(cancellationToken)
 {
     decimal sum;
-    bool hasValue;
 
     protected override void OnNextCore(TSource value)
     {
-        hasValue = true;
-        sum += selector(value);
+        var add = selector(value);
+        sum = checked(sum + add);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -357,33 +352,6 @@ internal sealed class SumDecimalAsync<TSource>(Func<TSource, decimal> selector, 
 }
 
 #if NET8_0_OR_GREATER
-internal sealed class SumNumber<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
-    where T : IAdditionOperators<T, T, T>
-{
-    T sum;
-
-    protected override void OnNextCore(T value)
-    {
-        sum += value;
-    }
-
-    protected override void OnErrorResumeCore(Exception error)
-    {
-        TrySetException(error);
-    }
-
-    protected override void OnCompletedCore(Result result)
-    {
-        if (result.IsFailure)
-        {
-            TrySetException(result.Exception);
-            return;
-        }
-
-        TrySetResult(sum);
-    }
-}
-
 internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
     where T : IAdditionOperators<T, T, T>
 {
@@ -391,7 +359,7 @@ internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : T
 
     protected override void OnNextCore(T value)
     {
-        sum += value;
+        sum = checked(sum + value);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -418,7 +386,8 @@ internal sealed class SumNumberAsync<TSource, TResult>(Func<TSource, TResult> se
 
     protected override void OnNextCore(TSource value)
     {
-        sum += selector(value);
+        var add = selector(value);
+        sum = checked(sum + add);
     }
 
     protected override void OnErrorResumeCore(Exception error)

--- a/src/R3/Operators/SumAsync.tt
+++ b/src/R3/Operators/SumAsync.tt
@@ -1,0 +1,244 @@
+<#@ template language="C#" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+    var typeNames = new[]
+    {
+        ("int", "Int32"),
+        ("long", "Int64"),
+        ("float", "Float"),
+        ("double", "Double"),
+        ("decimal", "Decimal")
+    };
+#>
+
+namespace R3;
+
+using System.Numerics;
+
+public static partial class ObservableExtensions
+{
+<# foreach (var (t, typeSuffix) in typeNames) { #>
+    public static Task<<#= t #>> SumAsync(this Observable<<#= t #>> source, CancellationToken cancellationToken = default)
+    {
+        var method = new Sum<#= typeSuffix #>Async(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<<#= t #>> SumAsync<TSource>(this Observable<TSource> source, Func<TSource, <#= t #>> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new Sum<#= typeSuffix #>Async<TSource>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+<# } #>
+
+#if NET8_0_OR_GREATER
+    public static Task<T> SumAsync<T>(this Observable<T> source, CancellationToken cancellationToken = default)
+        where T : IAdditionOperators<T, T, T>
+    {
+        var method = new SumNumberAsync<T>(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<TResult> SumAsync<TSource, TResult>(this Observable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken = default)
+        where TResult : IAdditionOperators<TResult, TResult, TResult>
+    {
+        var method = new SumNumberAsync<TSource, TResult>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+#endif
+}
+
+<# foreach (var (t, typeSuffix) in typeNames) { #>
+internal sealed class Sum<#= typeSuffix #>Async(CancellationToken cancellationToken) : TaskObserverBase<<#= t #>, <#= t #>>(cancellationToken)
+{
+    <#= t #> sum;
+    bool hasValue;
+
+    protected override void OnNextCore(<#= t #> value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class Sum<#= typeSuffix #>Async<TSource>(Func<TSource, <#= t #>> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, <#= t #>>(cancellationToken)
+{
+    <#= t #> sum;
+    bool hasValue;
+
+    protected override void OnNextCore(TSource value)
+    {
+        hasValue = true;
+        sum += selector(value);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+<# } #>
+
+
+#if NET8_0_OR_GREATER
+internal sealed class SumNumber<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
+    where T : IAdditionOperators<T, T, T>
+{
+    T sum;
+    bool hasValue;
+
+    protected override void OnNextCore(T value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
+    where T : IAdditionOperators<T, T, T>
+{
+    T sum;
+    bool hasValue;
+
+    protected override void OnNextCore(T value)
+    {
+        hasValue = true;
+        sum += value;
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+
+internal sealed class SumNumberAsync<TSource, TResult>(Func<TSource, TResult> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, TResult>(cancellationToken)
+    where TResult : IAdditionOperators<TResult, TResult, TResult>
+{
+    TResult sum;
+    bool hasValue;
+
+    protected override void OnNextCore(TSource value)
+    {
+        hasValue = true;
+        sum += selector(value);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(sum);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("no elements"));
+        }
+    }
+}
+#endif

--- a/src/R3/Operators/SumAsync.tt
+++ b/src/R3/Operators/SumAsync.tt
@@ -67,7 +67,7 @@ internal sealed class Sum<#= typeSuffix #>Async(CancellationToken cancellationTo
 
     protected override void OnNextCore(<#= t #> value)
     {
-        sum += value;
+        sum = checked(sum + value);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -89,12 +89,11 @@ internal sealed class Sum<#= typeSuffix #>Async(CancellationToken cancellationTo
 internal sealed class Sum<#= typeSuffix #>Async<TSource>(Func<TSource, <#= t #>> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, <#= t #>>(cancellationToken)
 {
     <#= t #> sum;
-    bool hasValue;
 
     protected override void OnNextCore(TSource value)
     {
-        hasValue = true;
-        sum += selector(value);
+        var add = selector(value);
+        sum = checked(sum + add);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -116,33 +115,6 @@ internal sealed class Sum<#= typeSuffix #>Async<TSource>(Func<TSource, <#= t #>>
 <# } #>
 
 #if NET8_0_OR_GREATER
-internal sealed class SumNumber<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
-    where T : IAdditionOperators<T, T, T>
-{
-    T sum;
-
-    protected override void OnNextCore(T value)
-    {
-        sum += value;
-    }
-
-    protected override void OnErrorResumeCore(Exception error)
-    {
-        TrySetException(error);
-    }
-
-    protected override void OnCompletedCore(Result result)
-    {
-        if (result.IsFailure)
-        {
-            TrySetException(result.Exception);
-            return;
-        }
-
-        TrySetResult(sum);
-    }
-}
-
 internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
     where T : IAdditionOperators<T, T, T>
 {
@@ -150,7 +122,7 @@ internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : T
 
     protected override void OnNextCore(T value)
     {
-        sum += value;
+        sum = checked(sum + value);
     }
 
     protected override void OnErrorResumeCore(Exception error)
@@ -177,7 +149,8 @@ internal sealed class SumNumberAsync<TSource, TResult>(Func<TSource, TResult> se
 
     protected override void OnNextCore(TSource value)
     {
-        sum += selector(value);
+        var add = selector(value);
+        sum = checked(sum + add);
     }
 
     protected override void OnErrorResumeCore(Exception error)

--- a/src/R3/Operators/SumAsync.tt
+++ b/src/R3/Operators/SumAsync.tt
@@ -64,11 +64,9 @@ public static partial class ObservableExtensions
 internal sealed class Sum<#= typeSuffix #>Async(CancellationToken cancellationToken) : TaskObserverBase<<#= t #>, <#= t #>>(cancellationToken)
 {
     <#= t #> sum;
-    bool hasValue;
 
     protected override void OnNextCore(<#= t #> value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -84,15 +82,7 @@ internal sealed class Sum<#= typeSuffix #>Async(CancellationToken cancellationTo
             TrySetException(result.Exception);
             return;
         }
-
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -120,29 +110,19 @@ internal sealed class Sum<#= typeSuffix #>Async<TSource>(Func<TSource, <#= t #>>
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 <# } #>
-
 
 #if NET8_0_OR_GREATER
 internal sealed class SumNumber<T>(CancellationToken cancellationToken) : TaskObserverBase<T, T>(cancellationToken)
     where T : IAdditionOperators<T, T, T>
 {
     T sum;
-    bool hasValue;
 
     protected override void OnNextCore(T value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -159,14 +139,7 @@ internal sealed class SumNumber<T>(CancellationToken cancellationToken) : TaskOb
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -174,11 +147,9 @@ internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : T
     where T : IAdditionOperators<T, T, T>
 {
     T sum;
-    bool hasValue;
 
     protected override void OnNextCore(T value)
     {
-        hasValue = true;
         sum += value;
     }
 
@@ -195,14 +166,7 @@ internal sealed class SumNumberAsync<T>(CancellationToken cancellationToken) : T
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 
@@ -210,11 +174,9 @@ internal sealed class SumNumberAsync<TSource, TResult>(Func<TSource, TResult> se
     where TResult : IAdditionOperators<TResult, TResult, TResult>
 {
     TResult sum;
-    bool hasValue;
 
     protected override void OnNextCore(TSource value)
     {
-        hasValue = true;
         sum += selector(value);
     }
 
@@ -231,14 +193,7 @@ internal sealed class SumNumberAsync<TSource, TResult>(Func<TSource, TResult> se
             return;
         }
 
-        if (hasValue)
-        {
-            TrySetResult(sum);
-        }
-        else
-        {
-            TrySetException(new InvalidOperationException("no elements"));
-        }
+        TrySetResult(sum);
     }
 }
 #endif

--- a/src/R3/R3.csproj
+++ b/src/R3/R3.csproj
@@ -17,6 +17,10 @@
 
     <ItemGroup>
         <None Include="../../Icon.png" Pack="true" PackagePath="/" />
+        <None Update="Operators\SumAsync.tt">
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>SumAsync.cs</LastGenOutput>
+        </None>
     </ItemGroup>
 
     <ItemGroup>
@@ -82,6 +86,9 @@
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>
             <DependentUpon>ZipLatest.tt</DependentUpon>
+        </Compile>
+        <Compile Update="Operators\SumAsync.cs">
+          <DependentUpon>SumAsync.tt</DependentUpon>
         </Compile>
     </ItemGroup>
 

--- a/tests/R3.Tests/OperatorTests/AggregateTest.cs
+++ b/tests/R3.Tests/OperatorTests/AggregateTest.cs
@@ -1,6 +1,4 @@
-﻿using System.Reactive.Linq;
-
-namespace R3.Tests.OperatorTests;
+﻿namespace R3.Tests.OperatorTests;
 
 public class AggregateTest
 {
@@ -157,27 +155,6 @@ public class AggregateTest
             return x;
         }).OnErrorResumeAsFailure();
         await Assert.ThrowsAsync<Exception>(async () => await error.MinMaxAsync());
-    }
-
-    [Fact]
-    public async Task Sum()
-    {
-        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var sum = await source.SumAsync();
-
-        sum.Should().Be(36);
-
-        (await Observable.Return(999).SumAsync()).Should().Be(999);
-
-        var task = Observable.Empty<int>().SumAsync();
-        (await task).Should().Be(0);
-
-        var error = Observable.Range(1, 10).Select(x =>
-        {
-            if (x == 3) throw new Exception("foo");
-            return x;
-        }).OnErrorResumeAsFailure();
-        await Assert.ThrowsAsync<Exception>(async () => await error.MinAsync());
     }
 
     [Fact]

--- a/tests/R3.Tests/OperatorTests/SumTest.cs
+++ b/tests/R3.Tests/OperatorTests/SumTest.cs
@@ -1,0 +1,52 @@
+using System.Numerics;
+
+namespace R3.Tests.OperatorTests;
+
+public class SumTest
+{
+    [Fact]
+    public async Task Empty()
+    {
+        (await Observable.Empty<int>().SumAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task One()
+    {
+        (await Observable.Return(999).SumAsync()).Should().Be(999);
+    }
+
+    [Fact]
+    public async Task Error()
+    {
+        var error = Observable.Range(0, 10).Select(x =>
+        {
+            if (x == 3) throw new Exception("foo");
+            return x;
+        });
+
+        await Assert.ThrowsAsync<Exception>(async () => await error.SumAsync());
+        await Assert.ThrowsAsync<Exception>(async () => await error.OnErrorResumeAsFailure().SumAsync());
+    }
+
+    [Fact]
+    public async Task MultipleValues()
+    {
+        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
+        var sum = await source.SumAsync();
+
+        sum.Should().Be(36);
+    }
+    //
+    // [Fact]
+    // public async Task NumberType()
+    // {
+    //
+    // }
+    //
+    // record struct TestNumber(int Value) : IAdditionOperators<TestNumber, TestNumber, TestNumber>
+    // {
+    //     public static TestNumber operator +(TestNumber left, TestNumber right) =>
+    //         new(left.Value + right.Value);
+    // }
+}

--- a/tests/R3.Tests/OperatorTests/SumTest.cs
+++ b/tests/R3.Tests/OperatorTests/SumTest.cs
@@ -8,12 +8,14 @@ public class SumTest
     public async Task Empty()
     {
         (await Observable.Empty<int>().SumAsync()).Should().Be(0);
+        (await Observable.Empty<TestNumber>().SumAsync()).Value.Should().Be(0);
     }
 
     [Fact]
     public async Task One()
     {
         (await Observable.Return(999).SumAsync()).Should().Be(999);
+        (await Observable.Return(new TestNumber(999)).SumAsync()).Value.Should().Be(999);
     }
 
     [Fact]
@@ -33,20 +35,38 @@ public class SumTest
     public async Task MultipleValues()
     {
         var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var sum = await source.SumAsync();
+        (await source.SumAsync()).Should().Be(36);
 
-        sum.Should().Be(36);
+        var source2 = source.Select(x => new TestNumber(x));
+        (await source2.SumAsync()).Value.Should().Be(36);
     }
-    //
-    // [Fact]
-    // public async Task NumberType()
-    // {
-    //
-    // }
-    //
-    // record struct TestNumber(int Value) : IAdditionOperators<TestNumber, TestNumber, TestNumber>
-    // {
-    //     public static TestNumber operator +(TestNumber left, TestNumber right) =>
-    //         new(left.Value + right.Value);
-    // }
+
+    [Fact]
+    public async Task WithSelector()
+    {
+        var source = new[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
+
+        (await source.SumAsync(x => x * 10f)).Should().Be(360f);
+        (await source.SumAsync(x => new TestNumber(x))).Value.Should().Be(36);
+    }
+
+    [Fact]
+    public async Task WithSelectorError()
+    {
+        var error = Observable.Range(1, 10).Select(x =>
+        {
+            if (x == 3) throw new Exception("foo");
+            return x;
+        });
+
+        await Assert.ThrowsAsync<Exception>(async () => await error.SumAsync(x => x));
+        await Assert.ThrowsAsync<Exception>(async () => await error.OnErrorResumeAsFailure().SumAsync(x => x));
+        await Assert.ThrowsAsync<Exception>(async () => await Observable.Range(0, 10).SumAsync(x => throw new Exception("bra")));
+    }
+
+    record struct TestNumber(int Value) : IAdditionOperators<TestNumber, TestNumber, TestNumber>
+    {
+        public static TestNumber operator +(TestNumber left, TestNumber right) =>
+            new(left.Value + right.Value);
+    }
 }


### PR DESCRIPTION
#12 

Add  Sum for following signatures 

- `SumAsync(O<int>)`
- `SumAsync<TSource>(O<int>, Func<TSource, int>)`
- `SumAsync(O<long>)`
- `SumAsync<TSource>(O<long>, Func<TSource, long>)`   
- `SumAsync(O<float>)`
- `SumAsync<TSource>(O<long>, Func<TSource, long>)`  
- `SumAsync(O<double>)`
- `SumAsync<TSource>(O<double>, Func<TSource, double>)` 
- `SumAsync(O<decimal>)`
- `SumAsync<TSource>(O<decimal>, Func<TSource, decimal>)` 
- for .NET 8
    - `SumAsync<T>(O<T>) where IAdditionOperators<T, T, T>`
    - `SumAsync<TSource, TResult>(O<TSource>, Func<TSource, TResult>) where IAdditionOperators<TResult, TResult, TResult>`
