### PR TITLE
Add independent impl AverageAsync

### DIFF
--- a/src/R3/Operators/AggregateOperators.cs
+++ b/src/R3/Operators/AggregateOperators.cs
@@ -109,23 +109,6 @@ public static partial class ObservableExtensions
         return AggregateAsync(source, default(T)!, static (sum, message) => checked(sum + message), Stubs<T>.ReturnSelf, cancellationToken); // ignore complete
     }
 
-    public static Task<double> AverageAsync<T>(this Observable<T> source, CancellationToken cancellationToken = default)
-        where T : INumberBase<T>
-    {
-        return AggregateAsync(source,
-            (sum: default(T)!, count: 0, hasValue: false),
-            static (avg, message) =>
-            {
-                return (checked(avg.sum + message), checked(avg.count + 1), true); // sum, count, hasValue
-            },
-            static (avg) =>
-            {
-                if (!avg.hasValue) throw new InvalidOperationException("Sequence contains no elements");
-                return double.CreateChecked(avg.sum) / double.CreateChecked(avg.count);
-            },
-            cancellationToken);
-    }
-
 #endif
 
     public static Task WaitAsync<T>(this Observable<T> source, CancellationToken cancellationToken = default)

--- a/src/R3/Operators/AverageAsync.cs
+++ b/src/R3/Operators/AverageAsync.cs
@@ -1,0 +1,517 @@
+﻿
+using System.Numerics;
+
+namespace R3;
+
+public static partial class ObservableExtensions
+{
+    public static Task<double> AverageAsync(this Observable<int> source, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageInt32Async(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync<T>(this Observable<T> source, Func<T, int> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageInt32Async<T>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync(this Observable<long> source, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageInt64Async(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync<T>(this Observable<T> source, Func<T, long> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageInt64Async<T>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync(this Observable<float> source, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageFloatAsync(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync<T>(this Observable<T> source, Func<T, float> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageFloatAsync<T>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync(this Observable<double> source, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageDoubleAsync(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync<T>(this Observable<T> source, Func<T, double> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageDoubleAsync<T>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync(this Observable<decimal> source, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageDecimalAsync(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync<T>(this Observable<T> source, Func<T, decimal> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new AverageDecimalAsync<T>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+#if NET8_0_OR_GREATER
+    public static Task<double> AverageAsync<T>(this Observable<T> source, CancellationToken cancellationToken = default)
+        where T : INumberBase<T>
+    {
+        var method = new AverageNumberAsync<T>(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync<TSource, TResult>(this Observable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken = default)
+        where TResult : INumberBase<TResult>
+    {
+        var method = new AverageNumberAsync<TSource, TResult>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+#endif
+}
+
+internal sealed class AverageInt32Async(CancellationToken cancellationToken) : TaskObserverBase<int, double>(cancellationToken)
+{
+    int sum;
+    int count;
+
+    protected override void OnNextCore(int value)
+    {
+        sum += value;
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(checked((double)sum) / count);
+    }
+}
+
+internal sealed class AverageInt32Async<TSource>(Func<TSource, int> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+{
+    int sum;
+    int count;
+
+    protected override void OnNextCore(TSource value)
+    {
+        sum += selector(value);
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(checked((double)sum) / count);
+    }
+}
+internal sealed class AverageInt64Async(CancellationToken cancellationToken) : TaskObserverBase<long, double>(cancellationToken)
+{
+    long sum;
+    int count;
+
+    protected override void OnNextCore(long value)
+    {
+        sum += value;
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(checked((double)sum) / count);
+    }
+}
+
+internal sealed class AverageInt64Async<TSource>(Func<TSource, long> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+{
+    long sum;
+    int count;
+
+    protected override void OnNextCore(TSource value)
+    {
+        sum += selector(value);
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(checked((double)sum) / count);
+    }
+}
+internal sealed class AverageFloatAsync(CancellationToken cancellationToken) : TaskObserverBase<float, double>(cancellationToken)
+{
+    float sum;
+    int count;
+
+    protected override void OnNextCore(float value)
+    {
+        sum += value;
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(checked((double)sum) / count);
+    }
+}
+
+internal sealed class AverageFloatAsync<TSource>(Func<TSource, float> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+{
+    float sum;
+    int count;
+
+    protected override void OnNextCore(TSource value)
+    {
+        sum += selector(value);
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(checked((double)sum) / count);
+    }
+}
+internal sealed class AverageDoubleAsync(CancellationToken cancellationToken) : TaskObserverBase<double, double>(cancellationToken)
+{
+    double sum;
+    int count;
+
+    protected override void OnNextCore(double value)
+    {
+        sum += value;
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(sum / count);
+    }
+}
+
+internal sealed class AverageDoubleAsync<TSource>(Func<TSource, double> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+{
+    double sum;
+    int count;
+
+    protected override void OnNextCore(TSource value)
+    {
+        sum += selector(value);
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(sum / count);
+    }
+}
+internal sealed class AverageDecimalAsync(CancellationToken cancellationToken) : TaskObserverBase<decimal, double>(cancellationToken)
+{
+    decimal sum;
+    int count;
+
+    protected override void OnNextCore(decimal value)
+    {
+        sum += value;
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(checked((double)sum) / count);
+    }
+}
+
+internal sealed class AverageDecimalAsync<TSource>(Func<TSource, decimal> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+{
+    decimal sum;
+    int count;
+
+    protected override void OnNextCore(TSource value)
+    {
+        sum += selector(value);
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        TrySetResult(checked((double)sum) / count);
+    }
+}
+
+#if NET8_0_OR_GREATER
+internal sealed class AverageNumberAsync<T>(CancellationToken cancellationToken) : TaskObserverBase<T, double>(cancellationToken)
+    where T : INumberBase<T>
+{
+    T sum;
+    int count;
+
+    protected override void OnNextCore(T value)
+    {
+        sum += value;
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        try
+        {
+            TrySetResult(double.CreateChecked(sum) / count);
+        }
+        catch (Exception ex)
+        {
+            TrySetException(ex);
+        }
+    }
+}
+
+internal sealed class AverageNumberAsync<TSource, TResult>(Func<TSource, TResult> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+    where TResult : INumberBase<TResult>
+{
+    TResult sum;
+    int count;
+
+    protected override void OnNextCore(TSource value)
+    {
+        sum = sum + selector(value);
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        try
+        {
+            TrySetResult(double.CreateChecked(sum) / count);
+        }
+        catch (Exception ex)
+        {
+            TrySetException(ex);
+        }
+    }
+}
+#endif

--- a/src/R3/Operators/AverageAsync.cs
+++ b/src/R3/Operators/AverageAsync.cs
@@ -462,14 +462,17 @@ internal sealed class AverageNumberAsync<T>(CancellationToken cancellationToken)
             return;
         }
 
+        double numerator;
         try
         {
-            TrySetResult(double.CreateChecked(sum) / count);
+            numerator = double.CreateChecked(sum);
         }
         catch (Exception ex)
         {
             TrySetException(ex);
+            return;
         }
+        TrySetResult(numerator / count);
     }
 }
 
@@ -504,14 +507,18 @@ internal sealed class AverageNumberAsync<TSource, TResult>(Func<TSource, TResult
             return;
         }
 
+        double numerator;
         try
         {
-            TrySetResult(double.CreateChecked(sum) / count);
+            numerator = double.CreateChecked(sum);
         }
         catch (Exception ex)
         {
             TrySetException(ex);
+            return;
         }
+
+        TrySetResult(numerator / count);
     }
 }
 #endif

--- a/src/R3/Operators/AverageAsync.tt
+++ b/src/R3/Operators/AverageAsync.tt
@@ -1,0 +1,224 @@
+<#@ template language="C#" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#
+    var typeNames = new[]
+    {
+        ("int", "Int32"),
+        ("long", "Int64"),
+        ("float", "Float"),
+        ("double", "Double"),
+        ("decimal", "Decimal")
+    };
+#>
+
+using System.Numerics;
+
+namespace R3;
+
+public static partial class ObservableExtensions
+{
+<# foreach (var (t, typeSuffix) in typeNames) { #>
+    public static Task<double> AverageAsync(this Observable<<#= t #>> source, CancellationToken cancellationToken = default)
+    {
+        var method = new Average<#= typeSuffix #>Async(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync<T>(this Observable<T> source, Func<T, <#= t #>> selector, CancellationToken cancellationToken = default)
+    {
+        var method = new Average<#= typeSuffix #>Async<T>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+<# } #>
+#if NET8_0_OR_GREATER
+    public static Task<double> AverageAsync<T>(this Observable<T> source, CancellationToken cancellationToken = default)
+        where T : INumberBase<T>
+    {
+        var method = new AverageNumberAsync<T>(cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+
+    public static Task<double> AverageAsync<TSource, TResult>(this Observable<TSource> source, Func<TSource, TResult> selector, CancellationToken cancellationToken = default)
+        where TResult : INumberBase<TResult>
+    {
+        var method = new AverageNumberAsync<TSource, TResult>(selector, cancellationToken);
+        source.Subscribe(method);
+        return method.Task;
+    }
+#endif
+}
+
+<# foreach (var (t, typeSuffix) in typeNames) { #>
+internal sealed class Average<#= typeSuffix #>Async(CancellationToken cancellationToken) : TaskObserverBase<<#= t #>, double>(cancellationToken)
+{
+    <#= t #> sum;
+    int count;
+
+    protected override void OnNextCore(<#= t #> value)
+    {
+        sum += value;
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+<# if (t == "double") { #>
+        TrySetResult(sum / count);
+<# } else { #>
+        TrySetResult(checked((double)sum) / count);
+<# } #>
+    }
+}
+
+internal sealed class Average<#= typeSuffix #>Async<TSource>(Func<TSource, <#= t #>> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+{
+    <#= t #> sum;
+    int count;
+
+    protected override void OnNextCore(TSource value)
+    {
+        sum += selector(value);
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+<# if (t == "double") { #>
+        TrySetResult(sum / count);
+<# } else { #>
+        TrySetResult(checked((double)sum) / count);
+<# } #>
+    }
+}
+<# } #>
+
+#if NET8_0_OR_GREATER
+internal sealed class AverageNumberAsync<T>(CancellationToken cancellationToken) : TaskObserverBase<T, double>(cancellationToken)
+    where T : INumberBase<T>
+{
+    T sum;
+    int count;
+
+    protected override void OnNextCore(T value)
+    {
+        sum += value;
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        try
+        {
+            TrySetResult(double.CreateChecked(sum) / count);
+        }
+        catch (Exception ex)
+        {
+            TrySetException(ex);
+        }
+    }
+}
+
+internal sealed class AverageNumberAsync<TSource, TResult>(Func<TSource, TResult> selector, CancellationToken cancellationToken) : TaskObserverBase<TSource, double>(cancellationToken)
+    where TResult : INumberBase<TResult>
+{
+    TResult sum;
+    int count;
+
+    protected override void OnNextCore(TSource value)
+    {
+        sum = sum + selector(value);
+        count = checked(count + 1);
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (count <= 0)
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+            return;
+        }
+
+        try
+        {
+            TrySetResult(double.CreateChecked(sum) / count);
+        }
+        catch (Exception ex)
+        {
+            TrySetException(ex);
+        }
+    }
+}
+#endif

--- a/src/R3/Operators/AverageAsync.tt
+++ b/src/R3/Operators/AverageAsync.tt
@@ -169,14 +169,17 @@ internal sealed class AverageNumberAsync<T>(CancellationToken cancellationToken)
             return;
         }
 
+        double numerator;
         try
         {
-            TrySetResult(double.CreateChecked(sum) / count);
+            numerator = double.CreateChecked(sum);
         }
         catch (Exception ex)
         {
             TrySetException(ex);
+            return;
         }
+        TrySetResult(numerator / count);
     }
 }
 
@@ -211,14 +214,18 @@ internal sealed class AverageNumberAsync<TSource, TResult>(Func<TSource, TResult
             return;
         }
 
+        double numerator;
         try
         {
-            TrySetResult(double.CreateChecked(sum) / count);
+            numerator = double.CreateChecked(sum);
         }
         catch (Exception ex)
         {
             TrySetException(ex);
+            return;
         }
+
+        TrySetResult(numerator / count);
     }
 }
 #endif

--- a/src/R3/R3.csproj
+++ b/src/R3/R3.csproj
@@ -17,6 +17,10 @@
 
     <ItemGroup>
         <None Include="../../Icon.png" Pack="true" PackagePath="/" />
+        <None Update="Operators\AverageAsync.tt">
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>AverageAsync.cs</LastGenOutput>
+        </None>
     </ItemGroup>
 
     <ItemGroup>
@@ -82,6 +86,11 @@
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>
             <DependentUpon>ZipLatest.tt</DependentUpon>
+        </Compile>
+        <Compile Update="Operators\AverageAsync.cs">
+          <AutoGen>True</AutoGen>
+          <DesignTime>True</DesignTime>
+          <DependentUpon>AverageAsync.tt</DependentUpon>
         </Compile>
     </ItemGroup>
 

--- a/tests/R3.Tests/OperatorTests/AggregateTest.cs
+++ b/tests/R3.Tests/OperatorTests/AggregateTest.cs
@@ -181,27 +181,6 @@ public class AggregateTest
     }
 
     [Fact]
-    public async Task Avg()
-    {
-        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var avg = await source.AverageAsync();
-
-        avg.Should().Be(new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.Average());
-
-        (await Observable.Return(999).AverageAsync()).Should().Be(999);
-
-        var task = Observable.Empty<int>().AverageAsync();
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
-
-        var error = Observable.Range(1, 10).Select(x =>
-        {
-            if (x == 3) throw new Exception("foo");
-            return x;
-        }).OnErrorResumeAsFailure();
-        await Assert.ThrowsAsync<Exception>(async () => await error.AverageAsync());
-    }
-
-    [Fact]
     public async Task WaitAsync()
     {
         var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();

--- a/tests/R3.Tests/OperatorTests/AverageTest.cs
+++ b/tests/R3.Tests/OperatorTests/AverageTest.cs
@@ -1,0 +1,333 @@
+using System.Globalization;
+using System.Numerics;
+
+namespace R3.Tests.OperatorTests;
+
+public class AverageTest
+{
+    [Fact]
+    public async Task Empty()
+    {
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await Observable.Empty<int>().AverageAsync();
+        });
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await Observable.Empty<TestNumber>().AverageAsync();
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await Observable.Empty<int>().AverageAsync(x => x);
+        });
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await Observable.Empty<TestNumber>().AverageAsync(x => x);
+        });
+    }
+
+    [Fact]
+    public async Task One()
+    {
+        (await Observable.Return(7).AverageAsync()).Should().Be(7.0);
+        (await Observable.Return(7).AverageAsync(x => x * 10)).Should().Be(70.0);
+        (await Observable.Return(new TestNumber(7)).AverageAsync()).Should().Be(7.0);
+        (await Observable.Return(new TestNumber(7)).AverageAsync(x => x)).Should().Be(7.0);
+    }
+
+    [Fact]
+    public async Task AnyValues()
+    {
+        var values = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 };
+
+        var result = await values.ToObservable().AverageAsync();
+        result.Should().Be(values.Average());
+
+        result = await values.ToObservable().AverageAsync(x => x * 2);
+        result.Should().Be(values.Average(x => x * 2));
+    }
+
+    [Fact]
+    public async Task Error()
+    {
+        var error = Observable.Range(0, 10).Select(x =>
+        {
+            if (x == 3) throw new Exception("foo");
+            return x;
+        });
+
+        await Assert.ThrowsAsync<Exception>(async () => await error.AverageAsync());
+        await Assert.ThrowsAsync<Exception>(async () => await error.OnErrorResumeAsFailure().AverageAsync());
+    }
+
+    [Fact]
+    public async Task SelectorError()
+    {
+        var o = Observable.Range(1, 10);
+
+        await Assert.ThrowsAsync<Exception>(async () => await o.AverageAsync(_ => throw new Exception("foo")));
+        await Assert.ThrowsAsync<Exception>(async () => await o.Select(x => new TestNumber(x)).AverageAsync(x => throw new Exception("bra")));
+    }
+
+    [Fact]
+    public async Task DoubleConvertError()
+    {
+        var o = Observable.Return(new TestNumber(100, CannotConvert: true));
+
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+        {
+            await o.AverageAsync();
+        });
+        await Assert.ThrowsAsync<NotSupportedException>(async () =>
+        {
+            await o.AverageAsync(x => x);
+        });
+    }
+}
+
+file record struct TestNumber(int Value, bool CannotConvert = false) : INumberBase<TestNumber>
+{
+    public static TestNumber operator +(TestNumber left, TestNumber right) =>
+        new(left.Value + right.Value, right.CannotConvert);
+
+    public static TestNumber operator /(TestNumber left, TestNumber right) =>
+        new(left.Value / right.Value, right.CannotConvert);
+
+    public string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber Parse(string s, IFormatProvider? provider)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryParse(string? s, IFormatProvider? provider, out TestNumber result)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out TestNumber result)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber AdditiveIdentity => throw new NotImplementedException();
+
+    public static TestNumber operator --(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber operator ++(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber MultiplicativeIdentity => throw new NotImplementedException();
+    public static TestNumber operator *(TestNumber left, TestNumber right)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber operator -(TestNumber left, TestNumber right)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber operator -(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber operator +(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber Abs(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsCanonical(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsComplexNumber(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsEvenInteger(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsFinite(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsImaginaryNumber(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsInfinity(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsInteger(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsNaN(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsNegative(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsNegativeInfinity(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsNormal(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsOddInteger(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsPositive(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsPositiveInfinity(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsRealNumber(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsSubnormal(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool IsZero(TestNumber value)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber MaxMagnitude(TestNumber x, TestNumber y)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber MaxMagnitudeNumber(TestNumber x, TestNumber y)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber MinMagnitude(TestNumber x, TestNumber y)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber MinMagnitudeNumber(TestNumber x, TestNumber y)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber Parse(string s, NumberStyles style, IFormatProvider? provider)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryConvertFromChecked<TOther>(TOther value, out TestNumber result) where TOther : INumberBase<TOther>
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryConvertFromSaturating<TOther>(TOther value, out TestNumber result) where TOther : INumberBase<TOther>
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryConvertFromTruncating<TOther>(TOther value, out TestNumber result) where TOther : INumberBase<TOther>
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryConvertToChecked<TOther>(TestNumber value, out TOther result) where TOther : INumberBase<TOther>
+    {
+        if (value.CannotConvert)
+        {
+            throw new NotSupportedException();
+        }
+
+        if (typeof(TOther) == typeof(double))
+        {
+            result = (TOther)(object)(double)value.Value;
+            return true;
+        }
+        throw new NotImplementedException();
+    }
+
+    public static bool TryConvertToSaturating<TOther>(TestNumber value, out TOther result) where TOther : INumberBase<TOther>
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryConvertToTruncating<TOther>(TestNumber value, out TOther result) where TOther : INumberBase<TOther>
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out TestNumber result)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool TryParse(string? s, NumberStyles style, IFormatProvider? provider, out TestNumber result)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static TestNumber One => throw new NotImplementedException();
+    public static int Radix => throw new NotImplementedException();
+    public static TestNumber Zero => throw new NotImplementedException();
+}


### PR DESCRIPTION
#12

Add Average for following signatures

- `AverageAsync(O<int>)`
- `AverageAsync(O<long>)`
- `AverageAsync(O<float>)` 
- `AverageAsync(O<double>)`  
- `AverageAsync(O<decimal>)`  
- `AverageAsync<TSource>(O<int>, Func<TSource, int>)`
- `AverageAsync<TSource>(O<long>, Func<TSource, long>)` 
- `AverageAsync<TSource>(O<long>, Func<TSource, float>)`  
- `AverageAsync<TSource>(O<long>, Func<TSource, double>)`  
- `AverageAsync<TSource>(O<long>, Func<TSource, decimal>)`  
- for .NET 8
  - `AverageAsync<T>(O<T>) where INumberBase<T>`
  - `AverageAsync<TSource, TResult>(O<TSource>, Func<TSource, TResult>) where INumberBase<TResult>`

Note:
`IAdditionOperators` and `IDivisionOperators` seemed sufficient to implement Average, but `INumberBase<>` constraint seems necessary to use `double.CreateCheched` (`double.TryConvertFrom`).
