### PR TITLE
Add BindableReactiveProperty

### DIFF
--- a/sandbox/ConsoleApp1/Program.cs
+++ b/sandbox/ConsoleApp1/Program.cs
@@ -1,21 +1,32 @@
 ﻿using ConsoleApp1;
 using R3;
+using System.ComponentModel.DataAnnotations;
 
 
 
 //Dump.Factory();
 
+var hoge = new Hoge();
 
+hoge.MyProperty1.ErrorsChanged += MyProperty1_ErrorsChanged;
+hoge.MyProperty2.ErrorsChanged += MyProperty2_ErrorsChanged;
 
-var subject = new Subject<int>();
-for (int i = 0; i < 10000; i++)
+void MyProperty1_ErrorsChanged(object? sender, System.ComponentModel.DataErrorsChangedEventArgs e)
 {
-    subject.Subscribe();
+    foreach (var item in hoge.MyProperty1.GetErrors(null!))
+    {
+        Console.WriteLine(item);
+    }
 }
-
-subject.Subscribe();
-subject.OnCompleted();
-Console.WriteLine(subject);
+void MyProperty2_ErrorsChanged(object? sender, System.ComponentModel.DataErrorsChangedEventArgs e)
+{
+    foreach (var item in hoge.MyProperty2.GetErrors(null!))
+    {
+        Console.WriteLine(item);
+    }
+}
+hoge.MyProperty1.Value = 30;
+hoge.MyProperty2.Value = 40;
 
 
 //SubscriptionTracker.EnableTracking = true;
@@ -71,3 +82,17 @@ Console.WriteLine(subject);
 //    }
 //}
 
+
+public class Hoge
+{
+    [Range(1, 10)]
+    public BindableReactiveProperty<int> MyProperty1 { get; set; } = new BindableReactiveProperty<int>().EnableValidation<Hoge>();
+
+    [Range(1, 10)]
+    public BindableReactiveProperty<int> MyProperty2 { get; set; }
+
+    public Hoge()
+    {
+        MyProperty2 = new BindableReactiveProperty<int>().EnableValidation(() => MyProperty2);
+    }
+}

--- a/sandbox/WpfApp1/MainWindow.xaml
+++ b/sandbox/WpfApp1/MainWindow.xaml
@@ -6,7 +6,23 @@
         xmlns:local="clr-namespace:WpfApp1"
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
-    <Grid>
-        <TextBlock Name="textBlock" HorizontalAlignment="Left" Margin="108,131,0,0" TextWrapping="Wrap" Text="TextBlock" VerticalAlignment="Top" Height="50" Width="292"/>
-    </Grid>
+    <Window.DataContext>
+        <!--<local:BasicUsagesViewModel />-->
+        <local:ValidationViewModel />
+    </Window.DataContext>
+    <!--<StackPanel>
+        <TextBlock Text="Basic usages" FontSize="24" />
+        <Label Content="Input" />
+        <TextBox Text="{Binding Input.Value, UpdateSourceTrigger=PropertyChanged}" />
+        <Label Content="Output" />
+        <TextBlock Text="{Binding Output.Value}" />
+    </StackPanel>-->
+
+    <StackPanel Margin="10">
+        <Label Content="Validation" />
+        <TextBox Text="{Binding Height.Value, UpdateSourceTrigger=PropertyChanged}"  />
+        <TextBox  Text="{Binding Weight.Value, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox  Text="{Binding CustomValidation1.Value, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBox  Text="{Binding CustomValidation2.Value, UpdateSourceTrigger=PropertyChanged}" />
+    </StackPanel>
 </Window>

--- a/sandbox/WpfApp1/MainWindow.xaml.cs
+++ b/sandbox/WpfApp1/MainWindow.xaml.cs
@@ -1,6 +1,8 @@
 ﻿using R3;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Windows;
+using System.Windows.Media.Media3D;
 
 namespace WpfApp1;
 /// <summary>
@@ -12,6 +14,9 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
 
+        //var vm = new BasicUsagesViewModel();
+        //vm.Input.Value = "hogemogehugahuga";
+        //this.DataContext = new BasicUsagesViewModel();
 
 
         //Dispatcher.Yield(DispatcherPriority.Input);
@@ -25,22 +30,86 @@ public partial class MainWindow : Window
         //Observable.EveryValueChanged(this, x => x.Width).Subscribe(x => textBlock.Text = x.ToString());
         // this.ObserveEveryValueChanged(x => x.Height).Subscribe(x => HeightText.Text = x.ToString());
 
-        var sw = Stopwatch.StartNew();
+        // var sw = Stopwatch.StartNew();
 
         //System.Reactive.Linq.Observable.Timer(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5)).Subscribe(_ =>
         //{
         //    textBlock.Text = "Hello World:" + sw.Elapsed;
         //});
-        Observable.Timer(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5))
-        //    // .ObserveOnCurrentDispatcher()
-            .Subscribe(_ =>
-            {
-                textBlock.Text = "Hello World:" + sw.Elapsed;
-            });
+        //Observable.Timer(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5))
+        ////    // .ObserveOnCurrentDispatcher()
+        //    .Subscribe(_ =>
+        //    {
+        //        textBlock.Text = "Hello World:" + sw.Elapsed;
+        //    });
 
         //Observable.TimerFrame(50, 100).Subscribe(_ =>
         //{
         //    textBlock.Text = "Hello World:" + ObservableSystem.DefaultFrameProvider.GetFrameCount();
         //});
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        (this.DataContext as IDisposable)?.Dispose();
+    }
+}
+
+public class BasicUsagesViewModel : IDisposable
+{
+    public BindableReactiveProperty<string> Input { get; }
+    public BindableReactiveProperty<string> Output { get; }
+
+    public BasicUsagesViewModel()
+    {
+        Input = new BindableReactiveProperty<string>("");
+        Output = Input.Select(x => x.ToUpper()).ToBindableReactiveProperty("");
+    }
+
+    public void Dispose()
+    {
+        Disposable.Dispose(Input, Output);
+    }
+}
+
+public class ValidationViewModel : IDisposable
+{
+    // Pattern 1. use EnableValidation<T> to enable DataAnnotation validation in field initializer
+    [Range(0.0, 300.0)]
+    public BindableReactiveProperty<double> Height { get; } = new BindableReactiveProperty<double>().EnableValidation<ValidationViewModel>();
+
+    [Range(0.0, 300.0)]
+    public BindableReactiveProperty<double> Weight { get; }
+
+    IDisposable customValidation1Subscription;
+    public BindableReactiveProperty<double> CustomValidation1 { get; set; }
+
+    public BindableReactiveProperty<double> CustomValidation2 { get; set; }
+
+    public ValidationViewModel()
+    {
+        // Pattern 2. use EnableValidation(Expression) to enable DataAnnotation validation
+        Weight = new BindableReactiveProperty<double>().EnableValidation(() => Weight);
+
+        // Pattern 3. EnableValidation() and call OnErrorResume to set custom error meessage
+        CustomValidation1 = new BindableReactiveProperty<double>().EnableValidation();
+        customValidation1Subscription = CustomValidation1.Subscribe(x =>
+        {
+            if (0.0 <= x && x <= 300.0) return;
+
+            CustomValidation1.OnErrorResume(new Exception("value is not in range."));
+        });
+
+        // Pattern 4. simplified version of Pattern3, EnableValidation(Func<T, Exception?>)
+        CustomValidation2 = new BindableReactiveProperty<double>().EnableValidation(x =>
+        {
+            if (0.0 <= x && x <= 300.0) return null; // null is no validate result
+            return new Exception("value is not in range.");
+        });
+    }
+
+    public void Dispose()
+    {
+        Disposable.Dispose(Height, Weight, CustomValidation1, customValidation1Subscription, CustomValidation2);
     }
 }

--- a/src/R3/BindableReactiveProperty.cs
+++ b/src/R3/BindableReactiveProperty.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections;
+using System.ComponentModel;
+
+namespace R3;
+
+// all operators need to call from UI Thread(not thread-safe)
+public class BindableReactiveProperty<T> : ReactiveProperty<T>, INotifyPropertyChanged, INotifyDataErrorInfo
+{
+    // for INotifyPropertyChanged
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected override void OnSetValue(T value)
+    {
+        PropertyChanged?.Invoke(this, ValueChangedEventArgs.PropertyChanged);
+    }
+
+    // for INotifyDataErrorInfo
+
+    public bool EnableNotifyError { get; init; } = true; // default is true, if false, don't allocate List<T>.
+
+    List<Exception>? errors;
+
+    public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
+
+    public bool HasErrors
+    {
+        get
+        {
+            if (errors == null) return false;
+            return errors.Count != 0;
+        }
+    }
+
+    public IEnumerable GetErrors(string? propertyName)
+    {
+        if (errors == null) return Enumerable.Empty<Exception>();
+        return errors;
+    }
+
+    protected override void OnReceiveError(Exception exception)
+    {
+        if (!EnableNotifyError) return;
+
+        if (errors == null)
+        {
+            errors = new List<Exception>();
+        }
+        errors.Add(exception);
+        ErrorsChanged?.Invoke(this, ValueChangedEventArgs.DataErrorsChanged);
+    }
+
+    public void ResetError()
+    {
+        if (errors != null)
+        {
+            errors.Clear();
+        }
+    }
+}
+
+internal static class ValueChangedEventArgs
+{
+    internal static readonly PropertyChangedEventArgs PropertyChanged = new PropertyChangedEventArgs("Value");
+    internal static readonly DataErrorsChangedEventArgs DataErrorsChanged = new DataErrorsChangedEventArgs("Value");
+}

--- a/src/R3/Disposable.cs
+++ b/src/R3/Disposable.cs
@@ -1,4 +1,5 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
 using System.Runtime.CompilerServices;
 
 namespace R3;
@@ -162,6 +163,113 @@ public static class Disposable
     public static IDisposable Combine(params IDisposable[] disposables)
     {
         return new CombinedDisposable(disposables);
+    }
+
+    public static void Dispose(IDisposable disposable1, IDisposable disposable2)
+    {
+        disposable1.Dispose();
+        disposable2.Dispose();
+    }
+
+    public static void Dispose(IDisposable disposable1, IDisposable disposable2, IDisposable disposable3)
+    {
+        disposable1.Dispose();
+        disposable2.Dispose();
+        disposable3.Dispose();
+
+    }
+
+    public static void Dispose(
+        IDisposable disposable1,
+        IDisposable disposable2,
+        IDisposable disposable3,
+        IDisposable disposable4
+        )
+    {
+        disposable1.Dispose();
+        disposable2.Dispose();
+        disposable3.Dispose();
+        disposable4.Dispose();
+    }
+
+    public static void Dispose(
+        IDisposable disposable1,
+        IDisposable disposable2,
+        IDisposable disposable3,
+        IDisposable disposable4,
+        IDisposable disposable5
+        )
+    {
+        disposable1.Dispose();
+        disposable2.Dispose();
+        disposable3.Dispose();
+        disposable4.Dispose();
+        disposable5.Dispose();
+    }
+
+    public static void Dispose(
+        IDisposable disposable1,
+        IDisposable disposable2,
+        IDisposable disposable3,
+        IDisposable disposable4,
+        IDisposable disposable5,
+        IDisposable disposable6
+        )
+    {
+        disposable1.Dispose();
+        disposable2.Dispose();
+        disposable3.Dispose();
+        disposable4.Dispose();
+        disposable5.Dispose();
+        disposable6.Dispose();
+    }
+
+    public static void Dispose(
+        IDisposable disposable1,
+        IDisposable disposable2,
+        IDisposable disposable3,
+        IDisposable disposable4,
+        IDisposable disposable5,
+        IDisposable disposable6,
+        IDisposable disposable7
+        )
+    {
+        disposable1.Dispose();
+        disposable2.Dispose();
+        disposable3.Dispose();
+        disposable4.Dispose();
+        disposable5.Dispose();
+        disposable6.Dispose();
+        disposable7.Dispose();
+    }
+
+    public static void Dispose(
+        IDisposable disposable1,
+        IDisposable disposable2,
+        IDisposable disposable3,
+        IDisposable disposable4,
+        IDisposable disposable5,
+        IDisposable disposable6,
+        IDisposable disposable7,
+        IDisposable disposable8
+        )
+    {
+        disposable1.Dispose();
+        disposable2.Dispose();
+        disposable3.Dispose();
+        disposable4.Dispose();
+        disposable5.Dispose();
+        disposable6.Dispose();
+        disposable7.Dispose();
+        disposable8.Dispose();
+    }
+
+    public static void Dispose(params IDisposable[] disposables)
+    {
+        foreach (var item in disposables)
+        {
+            item.Dispose();
+        }
     }
 }
 

--- a/src/R3/Factories/Create.cs
+++ b/src/R3/Factories/Create.cs
@@ -17,7 +17,7 @@ internal sealed class AnonymousObservable<T>(Func<Observer<T>, IDisposable> subs
 {
     protected override IDisposable SubscribeCore(Observer<T> observer)
     {
-        return subscribe(observer);
+        return subscribe(observer.Wrap());
     }
 }
 
@@ -25,6 +25,6 @@ internal sealed class AnonymousObservable<T, TState>(TState state, Func<Observer
 {
     protected override IDisposable SubscribeCore(Observer<T> observer)
     {
-        return subscribe(observer, state);
+        return subscribe(observer.Wrap(), state);
     }
 }

--- a/src/R3/R3.csproj
+++ b/src/R3/R3.csproj
@@ -50,6 +50,7 @@
         <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/R3/ReactiveProperty.cs
+++ b/src/R3/ReactiveProperty.cs
@@ -1,15 +1,18 @@
 ﻿namespace R3;
 
-public abstract class ReadOnlyReactiveProperty<T> : Observable<T>
+public abstract class ReadOnlyReactiveProperty<T> : Observable<T>, IDisposable
 {
     public abstract T CurrentValue { get; }
+    protected virtual void OnSetValue(T value) { }
+    protected virtual void OnReceiveError(Exception exception) { }
     public ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty() => this;
+    public abstract void Dispose();
 }
 
 // almostly same code as Subject<T>.
 
 // allow inherit
-public class ReactiveProperty<T> : ReadOnlyReactiveProperty<T>, ISubject<T>, IDisposable
+public class ReactiveProperty<T> : ReadOnlyReactiveProperty<T>, ISubject<T>
 {
     T value;
     IEqualityComparer<T>? equalityComparer;
@@ -48,7 +51,7 @@ public class ReactiveProperty<T> : ReadOnlyReactiveProperty<T>, ISubject<T>, IDi
     {
     }
 
-    public ReactiveProperty(T value, EqualityComparer<T>? equalityComparer)
+    public ReactiveProperty(T value, IEqualityComparer<T>? equalityComparer)
     {
         this.value = value;
         this.equalityComparer = equalityComparer;
@@ -126,7 +129,7 @@ public class ReactiveProperty<T> : ReadOnlyReactiveProperty<T>, ISubject<T>, IDi
         return subscription;
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         Dispose(true);
     }
@@ -150,9 +153,6 @@ public class ReactiveProperty<T> : ReadOnlyReactiveProperty<T>, ISubject<T>, IDi
     }
 
     protected virtual void DisposeCore() { }
-
-    protected virtual void OnSetValue(T value) { }
-    protected virtual void OnReceiveError(Exception exception) { }
 
     public override string? ToString()
     {

--- a/src/R3/ReactiveProperty.cs
+++ b/src/R3/ReactiveProperty.cs
@@ -72,6 +72,8 @@ public class ReactiveProperty<T> : ReadOnlyReactiveProperty<T>, ISubject<T>, IDi
     {
         if (completeState.IsCompleted) return;
 
+        OnReceiveError(error);
+
         foreach (var subscription in list.AsSpan())
         {
             subscription?.observer.OnErrorResume(error);
@@ -84,6 +86,11 @@ public class ReactiveProperty<T> : ReadOnlyReactiveProperty<T>, ISubject<T>, IDi
         if (status != CompleteState.ResultStatus.Done)
         {
             return; // already completed
+        }
+
+        if (result.IsFailure)
+        {
+            OnReceiveError(result.Exception);
         }
 
         foreach (var subscription in list.AsSpan())
@@ -145,6 +152,7 @@ public class ReactiveProperty<T> : ReadOnlyReactiveProperty<T>, ISubject<T>, IDi
     protected virtual void DisposeCore() { }
 
     protected virtual void OnSetValue(T value) { }
+    protected virtual void OnReceiveError(Exception exception) { }
 
     public override string? ToString()
     {

--- a/src/R3/ReactivePropertyExtensions.cs
+++ b/src/R3/ReactivePropertyExtensions.cs
@@ -7,7 +7,7 @@ public static class ReactivePropertyExtensions
         return source.ToReadOnlyReactiveProperty(EqualityComparer<T>.Default, initialValue);
     }
 
-    public static ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty<T>(this Observable<T> source, EqualityComparer<T>? equalityComparer, T initialValue = default!)
+    public static ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty<T>(this Observable<T> source, IEqualityComparer<T>? equalityComparer, T initialValue = default!)
     {
         if (source is ReadOnlyReactiveProperty<T> rrp)
         {
@@ -17,13 +17,25 @@ public static class ReactivePropertyExtensions
         // allow to cast ReactiveProperty<T>
         return new ConnectedReactiveProperty<T>(source, initialValue, equalityComparer);
     }
+
+    // ToBindable
+
+    public static BindableReactiveProperty<T> ToBindableReactiveProperty<T>(this Observable<T> source, T initialValue = default!)
+    {
+        return new BindableReactiveProperty<T>(source, initialValue, EqualityComparer<T>.Default);
+    }
+
+    public static BindableReactiveProperty<T> ToBindableReactiveProperty<T>(this Observable<T> source, IEqualityComparer<T>? equalityComparer, T initialValue = default!)
+    {
+        return new BindableReactiveProperty<T>(source, initialValue, equalityComparer);
+    }
 }
 
 internal sealed class ConnectedReactiveProperty<T> : ReactiveProperty<T>
 {
     readonly IDisposable sourceSubscription;
 
-    public ConnectedReactiveProperty(Observable<T> source, T initialValue, EqualityComparer<T>? equalityComparer)
+    public ConnectedReactiveProperty(Observable<T> source, T initialValue, IEqualityComparer<T>? equalityComparer)
         : base(initialValue, equalityComparer)
     {
         this.sourceSubscription = source.Subscribe(new Observer(this));

--- a/tests/R3.Tests/FactoryTests/CreateTest.cs
+++ b/tests/R3.Tests/FactoryTests/CreateTest.cs
@@ -24,7 +24,7 @@ public class CreateTest
         using var publisher = new Subject<int>();
         var source = Observable.Create<int, Subject<int>>(publisher, (observer, state) =>
         {
-            return state.Subscribe(new Wrap<int>(observer));
+            return state.Subscribe(observer);
         });
 
         using var list = source.ToLiveList();
@@ -41,20 +41,3 @@ public class CreateTest
     }
 }
 
-file class Wrap<T>(Observer<T> observer) : Observer<T>
-{
-    protected override void OnCompletedCore(Result result)
-    {
-        observer.OnCompleted(result);
-    }
-
-    protected override void OnErrorResumeCore(Exception error)
-    {
-        observer.OnErrorResume(error);
-    }
-
-    protected override void OnNextCore(T value)
-    {
-        observer.OnNext(value);
-    }
-}


### PR DESCRIPTION
#39 
If it's okay, I'd like to hear your opinions (on Twitter as well) @runceel, @xin9le

I have prepared a class that implements INotifyPropertyChanged and INotifyDataErrorInfo for binding in XAML.
In [runceel/ReactiveProperty](https://github.com/runceel/ReactiveProperty/), the relationship seems to be such that ReactiveProperty becomes ReactivePropertySlim, and BindableReactiveProperty becomes ReactiveProperty.

In R3, since ReactiveProperty is a Subject (BehaviorSubject) and does not stop on OnError, I made it so that calling OnErrorResume from outside will set an error flag.
It would be good if OnErrorResume is called from external validation or error streams.
For clearing the error, I thought it would be sufficient to have ResetError called separately.

Would this approach work without issues in WPF (or other XAML platforms)?