### PR TITLE
Add GodotUINodeExtensions

### DIFF
--- a/src/R3.Godot/addons/R3.Godot/GodotUINodeExtensions.cs
+++ b/src/R3.Godot/addons/R3.Godot/GodotUINodeExtensions.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Threading;
+using Godot;
+
+namespace R3;
+
+public static class GodotUINodeExtensions
+{
+    public static IDisposable SubscribeToLabel(this Observable<string> source, Label label)
+    {
+        return source.Subscribe(label, static (x, l) => l.Text = x);
+    }
+
+    public static IDisposable SubscribeToLabel<T>(this Observable<T> source, Label label)
+    {
+        return source.Subscribe(label, static (x, l) => l.Text = x?.ToString());
+    }
+
+    public static IDisposable SubscribeToLabel<T>(this Observable<T> source, Label label, Func<T, string> selector)
+    {
+        return source.Subscribe((label, selector), static (x, state) => state.label.Text = state.selector(x));
+    }
+
+    /// <summary>Observe Pressed event.</summary>
+    public static Observable<Unit> OnPressedAsObservable(this BaseButton button, CancellationToken cancellationToken)
+    {
+        return Observable.FromEvent(h => button.Pressed += h, h => button.Pressed -= h, cancellationToken);
+    }
+
+    /// <summary>Observe Toggled with current `ButtonPressed` value on subscribe.</summary>
+    public static Observable<bool> OnToggledAsObservable(this BaseButton button, CancellationToken cancellationToken)
+    {
+        if (!button.ToggleMode) return Observable.Empty<bool>();
+
+        return Observable.Create<bool, (BaseButton, CancellationToken)>((button, cancellationToken), static (observer, state) =>
+        {
+            var (b, cancellationToken) = state;
+            observer.OnNext(b.ButtonPressed);
+            return Observable.FromEvent<BaseButton.ToggledEventHandler, bool>(h => new BaseButton.ToggledEventHandler(h), h => b.Toggled += h, h => b.Toggled -= h, cancellationToken).Subscribe(observer.Wrap());
+        });
+    }
+
+    /// <summary>Observe ValueChanged with current `Value` on subscribe.</summary>
+    public static Observable<double> OnValueChangedAsObservable(this Godot.Range range, CancellationToken cancellationToken)
+    {
+        return Observable.Create<double, (Godot.Range, CancellationToken)>((range, cancellationToken), static (observer, state) =>
+        {
+            var (s, cancellationToken) = state;
+            observer.OnNext(s.Value);
+            return Observable.FromEvent<Godot.Range.ValueChangedEventHandler, double>(h => new Godot.Range.ValueChangedEventHandler(h), h => s.ValueChanged += h, h => s.ValueChanged -= h, cancellationToken).Subscribe(observer.Wrap());
+        });
+    }
+
+    /// <summary>Observe TextSubmitted event.</summary>
+    public static Observable<string> OnTextSubmittedAsObservable(this LineEdit lineEdit, CancellationToken cancellationToken)
+    {
+        return Observable.FromEvent<LineEdit.TextSubmittedEventHandler, string>(h => new LineEdit.TextSubmittedEventHandler(h), h => lineEdit.TextSubmitted += h, h => lineEdit.TextSubmitted -= h, cancellationToken);
+    }
+
+    /// <summary>Observe TextChanged event.</summary>
+    public static Observable<string> OnTextChangedAsObservable(this LineEdit lineEdit, CancellationToken cancellationToken)
+    {
+        return Observable.FromEvent<LineEdit.TextChangedEventHandler, string>(h => new LineEdit.TextChangedEventHandler(h), h => lineEdit.TextChanged += h, h => lineEdit.TextChanged -= h, cancellationToken);
+    }
+
+    /// <summary>Observe TextChanged event.</summary>
+    public static Observable<Unit> OnTextChangedAsObservable(this TextEdit textEdit, CancellationToken cancellationToken)
+    {
+        return Observable.FromEvent(h => textEdit.TextChanged += h, h => textEdit.TextChanged -= h, cancellationToken);
+    }
+
+    /// <summary>Observe ItemSelected with current `Selected` on subscribe.</summary>
+    public static Observable<long> OnItemSelectedAsObservable(this OptionButton optionButton, CancellationToken cancellationToken)
+    {
+        return Observable.Create<long, (OptionButton, CancellationToken)>((optionButton, cancellationToken), static (observer, state) =>
+        {
+            var (b, cancellationToken) = state;
+            observer.OnNext(b.Selected);
+            return Observable.FromEvent<OptionButton.ItemSelectedEventHandler, long>(h => new OptionButton.ItemSelectedEventHandler(h), h => b.ItemSelected += h, h => b.ItemSelected -= h, cancellationToken).Subscribe(observer.Wrap());
+        });
+    }
+}


### PR DESCRIPTION
This PR adds GodotUINodeExtensions to R3.Godot, which is equivalent to UnityUIComponentExtensions in R3.Unity.

- Since Godot don't have a base class corresponding to the `Selectable`, `SubscribeToInteractable` is excluded. (`Control` class don't have Disabled / Enabled stuff.)
- Godot don't have `destroyCancellationToken`, so methods require `CancellationToken` as an argument.
- I've adapted Godot's event names.


| R3.Unity                                | PR's R3.Godot               | 
| --------------------------------------- | --------------------------- | 
| SubscribeToText                         | SubscribeToLabel            | 
| SubscribeToInteractable                 | (none)                      | 
| OnClickAsObservable                     | OnPressedAsObservable       | 
| OnValueChangedAsObservable (Toggle)     | OnToggledAsObservable       | 
| OnValueChangedAsObservable (others)     | (same name)                 | 
| OnEndEditAsObservable                   | OnTextSubmittedAsObservable | 
| OnValueChangedAsObservable (InputField) | OnTextChangedAsObservable   | 
| OnValueChangedAsObservable (Dropdown)   | OnItemSelectedAsObservable  | 