### PR TITLE
FIX: R3.Unity dependencies

### DIFF
--- a/src/R3.Unity/Assets/R3.Unity/Runtime/R3.Unity.asmdef
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/R3.Unity.asmdef
@@ -13,6 +13,12 @@
     ],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.ugui",
+            "expression": "",
+            "define": "R3_UGUI_SUPPORT"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/src/R3.Unity/Assets/R3.Unity/Runtime/UnityUIComponentExtensions.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/UnityUIComponentExtensions.cs
@@ -1,4 +1,5 @@
-﻿using R3;
+#if R3_UGUI_SUPPORT
+using R3;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -101,3 +102,4 @@ namespace R3
         }
     }
 }
+#endif

--- a/src/R3.Unity/Assets/R3.Unity/package.json
+++ b/src/R3.Unity/Assets/R3.Unity/package.json
@@ -8,5 +8,7 @@
     "keywords": [ "rx", "event", "Scripting" ],
     "license": "MIT",
     "category": "Scripting",
-    "dependencies": {}
+    "dependencies": {
+        "com.unity.modules.imgui": "1.0.0"
+    }
 }


### PR DESCRIPTION
#26 

- `SerializableReactivePropertyDrawer` depends on `com.unity.modules.imgui`
- `UnityUIComponentExtensions.cs` depends on `com.unity.ugui` 


<details>

<summary>Current minimum configuration.</summary>

## manifest.json

```json
{
  "dependencies": {
    "com.cysharp.r3": "https://github.com/Cysharp/R3.git?path=src/R3.Unity/Assets/R3.Unity",
    "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity"
  }
}
```

## packages-lock.json

```json
{
  "dependencies": {
    "com.cysharp.r3": {
      "version": "file:com.cysharp.r3@7ea2939742",
      "depth": 0,
      "source": "embedded",
      "dependencies": {
        "com.unity.modules.imgui": "1.0.0"
      }
    },
    "com.github-glitchenzo.nugetforunity": {
      "version": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
      "depth": 0,
      "source": "git",
      "dependencies": {},
      "hash": "7388d28922b2144497f639630fd8b8b7a3c1ee6d"
    },
    "com.unity.modules.imgui": {
      "version": "1.0.0",
      "depth": 1,
      "source": "builtin",
      "dependencies": {}
    }
  }
}
```
</details>