### PR TITLE
Add more overloads of AggregateAsync

### DIFF
--- a/src/R3/Operators/AggregateAsync.cs
+++ b/src/R3/Operators/AggregateAsync.cs
@@ -2,10 +2,29 @@
 
 public static partial class ObservableExtensions
 {
-    // TODO: standard overload
+    public static Task<T> AggregateAsync<T>(
+        this Observable<T> source,
+        Func<T, T, T> func,
+        CancellationToken cancellationToken = default)
+    {
+        var observer = new AggregateAsync<T>(func, cancellationToken);
+        source.Subscribe(observer);
+        return observer.Task;
+    }
+
+    public static Task<TResult> AggregateAsync<T, TResult>(
+        this Observable<T> source,
+        TResult seed,
+        Func<TResult, T, TResult> func,
+        CancellationToken cancellationToken = default)
+    {
+        var observer = new AggregateAsync<T, TResult>(seed, func, cancellationToken);
+        source.Subscribe(observer);
+        return observer.Task;
+    }
 
     public static Task<TResult> AggregateAsync<T, TAccumulate, TResult>
-        (this Observable<T> source,
+    (this Observable<T> source,
         TAccumulate seed,
         Func<TAccumulate, T, TAccumulate> func,
         Func<TAccumulate, TResult> resultSelector,
@@ -16,6 +35,81 @@ public static partial class ObservableExtensions
         return observer.Task;
     }
 }
+
+internal sealed class AggregateAsync<T>(
+    Func<T, T, T> func,
+    CancellationToken cancellationToken)
+    : TaskObserverBase<T, T>(cancellationToken)
+{
+    T currentResult = default!;
+    bool hasValue;
+
+    protected override void OnNextCore(T value)
+    {
+        if (hasValue)
+        {
+            currentResult = func(currentResult, value); // OnNext error is route to OnErrorResumeCore
+        }
+        else
+        {
+            currentResult = value;
+            hasValue = true;
+        }
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+
+        if (hasValue)
+        {
+            TrySetResult(currentResult);
+        }
+        else
+        {
+            TrySetException(new InvalidOperationException("Sequence contains no elements"));
+        }
+    }
+}
+
+internal sealed class AggregateAsync<T, TResult>(
+    TResult seed,
+    Func<TResult, T, TResult> func,
+    CancellationToken cancellationToken)
+    : TaskObserverBase<T, TResult>(cancellationToken)
+{
+    TResult currentValue = seed;
+
+    protected override void OnNextCore(T value)
+    {
+        currentValue = func(currentValue, value); // OnNext error is route to OnErrorResumeCore
+    }
+
+    protected override void OnErrorResumeCore(Exception error)
+    {
+        TrySetException(error);
+    }
+
+    protected override void OnCompletedCore(Result result)
+    {
+        if (result.IsFailure)
+        {
+            TrySetException(result.Exception);
+            return;
+        }
+        TrySetResult(currentValue);
+    }
+}
+
 
 internal sealed class AggregateAsync<T, TAccumulate, TResult>(
     TAccumulate seed,

--- a/tests/R3.Tests/OperatorTests/AggregateTest.cs
+++ b/tests/R3.Tests/OperatorTests/AggregateTest.cs
@@ -3,11 +3,58 @@
 public class AggregateTest
 {
     [Fact]
+    public async Task Reduce()
+    {
+        var publisher = new Subject<int>();
+
+        var task = publisher.AggregateAsync((result, x) => result + x);
+
+        publisher.OnNext(1);
+        publisher.OnNext(2);
+        publisher.OnNext(3);
+        publisher.OnNext(4);
+        publisher.OnNext(5);
+
+        task.Status.Should().Be(TaskStatus.WaitingForActivation);
+
+        publisher.OnCompleted();
+
+        (await task).Should().Be(15);
+    }
+
+    [Fact]
+    public async Task ReduceEmptyElement()
+    {
+        var publisher = new Subject<int>();
+
+        var task = publisher.AggregateAsync((result, x) => result + x);
+        task.Status.Should().Be(TaskStatus.WaitingForActivation);
+
+        publisher.OnCompleted();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
+    }
+
+    [Fact]
+    public async Task ReduceOneElement()
+    {
+        var publisher = new Subject<int>();
+
+        var task = publisher.AggregateAsync((result, x) => result + x);
+        task.Status.Should().Be(TaskStatus.WaitingForActivation);
+
+        publisher.OnNext(100);
+        publisher.OnCompleted();
+
+        (await task).Should().Be(100);
+    }
+
+    [Fact]
     public async Task Aggregate()
     {
         var publisher = new Subject<int>();
 
-        var listTask = publisher.AggregateAsync(new List<int>(), (x, i) => { x.Add(i); return x; }, (x) => x);
+        var listTask = publisher.AggregateAsync(new List<int>(), (x, i) => { x.Add(i); return x; });
 
         publisher.OnNext(1);
         publisher.OnNext(2);
@@ -20,6 +67,26 @@ public class AggregateTest
         publisher.OnCompleted();
 
         (await listTask).Should().Equal(1, 2, 3, 4, 5);
+    }
+
+    [Fact]
+    public async Task AggregateWithResultSelector()
+    {
+        var publisher = new Subject<int>();
+
+        var task = publisher.AggregateAsync(0, (max, x) => max < x ? x : max, x => x.ToString());
+
+        publisher.OnNext(1);
+        publisher.OnNext(2);
+        publisher.OnNext(3);
+        publisher.OnNext(4);
+        publisher.OnNext(5);
+
+        task.Status.Should().Be(TaskStatus.WaitingForActivation);
+
+        publisher.OnCompleted();
+
+        (await task).Should().Be("5");
     }
 
     [Fact]
@@ -48,114 +115,4 @@ public class AggregateTest
 
         await Assert.ThrowsAsync<TaskCanceledException>(async () => await listTask);
     }
-
-    [Fact]
-    public async Task Min()
-    {
-        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var min = await source.MinAsync();
-
-        min.Should().Be(1);
-
-        (await Observable.Return(999).MinAsync()).Should().Be(999);
-
-        var task = Observable.Empty<int>().MinAsync();
-
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
-
-        var error = Observable.Range(1, 10).Select(x =>
-        {
-            if (x == 3) throw new Exception("foo");
-            return x;
-        }).OnErrorResumeAsFailure();
-        await Assert.ThrowsAsync<Exception>(async () => await error.MinAsync());
-    }
-
-    [Fact]
-    public async Task Max()
-    {
-        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var min = await source.MaxAsync();
-
-        min.Should().Be(10);
-
-        (await Observable.Return(999).MaxAsync()).Should().Be(999);
-
-        var task = Observable.Empty<int>().MaxAsync();
-
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
-
-        var error = Observable.Range(1, 10).Select(x =>
-        {
-            if (x == 3) throw new Exception("foo");
-            return x;
-        }).OnErrorResumeAsFailure();
-        await Assert.ThrowsAsync<Exception>(async () => await error.MaxAsync());
-    }
-
-    [Fact]
-    public async Task Count()
-    {
-        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var count = await source.CountAsync();
-
-        count.Should().Be(8);
-
-        var count2 = await Observable.Empty<int>().CountAsync();
-        count2.Should().Be(0);
-    }
-
-    [Fact]
-    public async Task LongCount()
-    {
-        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var count = await source.LongCountAsync();
-
-        count.Should().Be(8);
-
-        var count2 = await Observable.Empty<int>().LongCountAsync();
-        count2.Should().Be(0);
-
-        var error = Observable.Throw<int>(new Exception("foo"));
-
-        await Assert.ThrowsAsync<Exception>(async () => await error.LongCountAsync());
-    }
-
-    [Fact]
-    public async Task Sum()
-    {
-        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var sum = await source.SumAsync();
-
-        sum.Should().Be(36);
-
-        (await Observable.Return(999).SumAsync()).Should().Be(999);
-
-        var task = Observable.Empty<int>().SumAsync();
-        (await task).Should().Be(0);
-    }
-
-    [Fact]
-    public async Task Avg()
-    {
-        var source = new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.ToObservable();
-        var avg = await source.AverageAsync();
-
-        avg.Should().Be(new int[] { 1, 10, 1, 3, 4, 6, 7, 4 }.Average());
-
-        (await Observable.Return(999).AverageAsync()).Should().Be(999);
-
-        var task = Observable.Empty<int>().AverageAsync();
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await task);
-
-
-        var error = Observable.Range(1, 10).Select(x =>
-        {
-            if (x == 3) throw new Exception("foo");
-            return x;
-        }).OnErrorResumeAsFailure();
-
-        await Assert.ThrowsAsync<Exception>(async () => await error.MinAsync());
-    }
-
 }


### PR DESCRIPTION
#12 

Add the following AggregateAsync overlods.

-  `Task<T> AggregateAsync<T>(this Observable<T> source,  Func<T, T, T> func, CancellationToken cancellationToken);`
-  `Task<TResult> AggregateAsync<T, TResult>(this Observable<T> source, TResult seed, Func<TResult, T, TResult> func, CancellationToken cancellationToken)`

