### PR TITLE
Fix R3.Godot DefaultFrameProvider

### DIFF
--- a/src/R3.Godot/addons/R3.Godot/GodotProviderInitializer.cs
+++ b/src/R3.Godot/addons/R3.Godot/GodotProviderInitializer.cs
@@ -16,6 +16,6 @@ public static class GodotProviderInitializer
     {
         ObservableSystem.RegisterUnhandledExceptionHandler(unhandledExceptionHandler);
         ObservableSystem.DefaultTimeProvider = GodotTimeProvider.Process;
-        ObservableSystem.DefaultFrameProvider = GodotFrameProvider.PhysicsProcess;
+        ObservableSystem.DefaultFrameProvider = GodotFrameProvider.Process;
     }
 }


### PR DESCRIPTION
fix `DefaultFrameProvider` according to the description in README.

> autoloaded FrameProviderDispatcher set GodotTimeProvider.Process and GodotFrameProvider.Process as default providers.