### PR TITLE
Prevent stripping of UnityProviderInitializer

### DIFF
--- a/src/R3.Unity/Assets/R3.Unity/Runtime/UnityProviderInitializer.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/UnityProviderInitializer.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using UnityEngine;
 
+[assembly: UnityEngine.Scripting.AlwaysLinkAssembly]
+
 namespace R3
 {
     public static class UnityProviderInitializer


### PR DESCRIPTION
Fixed UnityProviderInitializer stripping on IL2CPP builds, causing it to not work properly.