### PR TITLE
chore: fix ReferenceBuilder path handling for VS Debug and dotnet run

### DIFF
--- a/sandbox/ReferenceBuilder/Program.cs
+++ b/sandbox/ReferenceBuilder/Program.cs
@@ -1,13 +1,17 @@
 ﻿using MarkdownGenerator;
+using System.Reflection;
 
 var f = Factory();
 var o = Operator();
 
-File.WriteAllText("../../../../../docs/reference_factory.md", f);
-File.WriteAllText("../../../../../docs/reference_operator.md", o);
+// Get absolute path of bin/Debug/TargetFramework/ReferenceBuilder.dll
+// Location = /Foo/Bar/R3/sandbox/ReferenceBuilder/bin/Debug/net8.0/ReferenceBuilder.dll
+var basePath = Assembly.GetAssembly(typeof(Program))!.Location;
+File.WriteAllText(Path.Combine(basePath, "../../../../../../docs/reference_factory.md"), f);
+File.WriteAllText(Path.Combine(basePath, "../../../../../../docs/reference_operator.md"), o);
 
 // replace readme
-var text = File.ReadAllLines("../../../../../ReadMe.md");
+var text = File.ReadAllLines(Path.Combine(basePath, "../../../../../../ReadMe.md"));
 
 (int head, int tail)? factoryLines = null;
 (int head, int tail)? operatorLines = null;
@@ -84,7 +88,7 @@ for (int i = 0; i < text.Length; i++)
 }
 
 var nt = string.Join(Environment.NewLine, newText);
-File.WriteAllText("../../../../../ReadMe.md", nt);
+File.WriteAllText(Path.Combine(basePath, "../../../../../../ReadMe.md"), nt);
 
 static string Factory()
 {


### PR DESCRIPTION
## tl;dr;

Current ReferenceBuilder output path is working for VS Debug run, but not for `dotnet run --project sandbox\ReferenceBuilder\ReferenceBuilder.csproj`. This PR fix to run on both.


```shell
$ dotnet run --project sandbox\ReferenceBuilder\ReferenceBuilder.csproj
Unhandled exception. System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\docs\reference_factory.md'.
   at Microsoft.Win32.SafeHandles.SafeFileHandle.CreateFile(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options)
   at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, Nullable`1 unixCreateMode)
   at System.IO.File.OpenHandle(String path, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize)
   at System.IO.File.WriteToFile(String path, FileMode mode, String contents, Encoding encoding)
   at Program.<Main>$(String[] args) in C:\github\cysharp\R3\sandbox\ReferenceBuilder\Program.cs:line 6
```


## TODO

* [x] Run on  `VS Debug Run`

```shell
(1175, 1268)
(1300, 1585)
```

* [x] Run on `dotnet run`

```shell
$ dotnet run --project sandbox\ReferenceBuilder\ReferenceBuilder.csproj
(1175, 1268)
(1300, 1585)
```
