### PR TITLE
GodotTimeProvider time calculate by delta

### DIFF
--- a/src/R3.Godot/addons/R3.Godot/FrameProviderDispatcher.cs
+++ b/src/R3.Godot/addons/R3.Godot/FrameProviderDispatcher.cs
@@ -20,12 +20,14 @@ public partial class FrameProviderDispatcher : global::Godot.Node
     public override void _Process(double delta)
     {
         processDelta.Value = delta;
+        ((GodotTimeProvider)GodotTimeProvider.Process).time += delta;
         ((GodotFrameProvider)GodotFrameProvider.Process).Run(delta);
     }
 
     public override void _PhysicsProcess(double delta)
     {
         physicsProcessDelta.Value = delta;
+        ((GodotTimeProvider)GodotTimeProvider.PhysicsProcess).time += delta;
         ((GodotFrameProvider)GodotFrameProvider.PhysicsProcess).Run(delta);
     }
 }

--- a/src/R3.Godot/addons/R3.Godot/GodotTimeProvider.cs
+++ b/src/R3.Godot/addons/R3.Godot/GodotTimeProvider.cs
@@ -13,6 +13,8 @@ public class GodotTimeProvider : TimeProvider
 
     readonly GodotFrameProvider frameProvider;
 
+    internal double time;
+
     GodotTimeProvider(FrameProvider frameProvider)
     {
         this.frameProvider = (GodotFrameProvider)frameProvider;
@@ -21,6 +23,11 @@ public class GodotTimeProvider : TimeProvider
     public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
     {
         return new FrameTimer(callback, state, dueTime, period, frameProvider);
+    }
+
+    public override long GetTimestamp()
+    {
+        return TimeSpan.FromSeconds(time).Ticks;
     }
 }
 


### PR DESCRIPTION
#79
The TimeProvider in Unity calculates using Unity time.   https://github.com/Cysharp/R3/blob/main/src/R3.Unity/Assets/R3.Unity/Runtime/UnityTimeProvider.cs#L77
In Godot, I tried modifying it to use Godot time by adding delta.

@aneuf-tech Do you have any concerns?