### PR TITLE
Added observable extensions for property changes

### DIFF
--- a/src/R3/PropertyChangedExtensions.cs
+++ b/src/R3/PropertyChangedExtensions.cs
@@ -1,0 +1,76 @@
+﻿using System.ComponentModel;
+
+namespace R3;
+
+public static class PropertyChangedExtensions
+{
+    /// <summary>
+    /// Extension method for INotifyPropertyChanged interface.
+    /// It creates an observable sequence that produces a value when the specified property has changed.
+    /// It will always emit the current value of the property upon subscription
+    /// </summary>
+    /// <typeparam name="TIn">The type of the object that implements INotifyPropertyChanged.</typeparam>
+    /// <typeparam name="TOut">The type of the value to be produced by the observable sequence.</typeparam>
+    /// <param name="propertyChanged">The object that implements INotifyPropertyChanged.</param>
+    /// <param name="propertyNameIn">The name of the property to observe for changes.</param>
+    /// <param name="valueSelect">A function to select the value to be produced by the observable sequence.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>An observable sequence that produces a value when the specified property has changed.</returns>
+
+    public static Observable<TOut> WhenChanged<TIn, TOut>(this TIn propertyChanged, string propertyNameIn, Func<TIn, TOut> valueSelect, CancellationToken cancellationToken = default)
+        where TIn : INotifyPropertyChanged
+    {
+        var initialValue = valueSelect(propertyChanged);
+
+        return
+            Observable.Merge(
+                Observable.Return(initialValue),
+                Observable
+                    .FromEvent<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                        static eventHandler =>
+                        {
+                            void Handler(object? sender, PropertyChangedEventArgs e) => eventHandler?.Invoke(e);
+                            return Handler;
+                        },
+                        x => propertyChanged.PropertyChanged += x,
+                        x => propertyChanged.PropertyChanged -= x,
+                        cancellationToken)
+                    .Where(propertyNameIn, static (args, state) => args.PropertyName.Equals(state))
+                    .Select((valueSelect, propertyChanged), static (_, state) => state.valueSelect(state.propertyChanged)));
+    }
+
+    /// <summary>
+    /// Extension method for INotifyPropertyChanging interface.
+    /// It creates an observable sequence that produces a value when the specified property is changing.
+    /// It will always emit the current value of the property upon subscription
+    /// </summary>
+    /// <typeparam name="TIn">The type of the object that implements INotifyPropertyChanging.</typeparam>
+    /// <typeparam name="TOut">The type of the value to be produced by the observable sequence.</typeparam>
+    /// <param name="propertyChanging">The object that implements INotifyPropertyChanging.</param>
+    /// <param name="propertyNameIn">The name of the property to observe for changes.</param>
+    /// <param name="valueSelect">A function to select the value to be produced by the observable sequence.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>An observable sequence that produces a value when the specified property is changing.</returns>
+
+    public static Observable<TOut> WhenChanging<TIn, TOut>(this TIn propertyChanging, string propertyNameIn, Func<TIn, TOut> valueSelect, CancellationToken cancellationToken = default)
+        where TIn : INotifyPropertyChanging
+    {
+        var initialValue = valueSelect(propertyChanging);
+
+        return
+            Observable.Merge(
+                Observable.Return(initialValue),
+                Observable
+                    .FromEvent<PropertyChangingEventHandler, PropertyChangingEventArgs>(
+                        static eventHandler =>
+                        {
+                            void Handler(object? sender, PropertyChangingEventArgs e) => eventHandler?.Invoke(e);
+                            return Handler;
+                        },
+                        x => propertyChanging.PropertyChanging += x,
+                        x => propertyChanging.PropertyChanging -= x,
+                        cancellationToken)
+                    .Where(propertyNameIn, static (args, state) => args.PropertyName.Equals(state))
+                    .Select((valueSelect, propertyChanging), static (_, state) => state.valueSelect(state.propertyChanging)));
+    }
+}

--- a/tests/R3.Tests/PropertyChangedExtensionsTest.cs
+++ b/tests/R3.Tests/PropertyChangedExtensionsTest.cs
@@ -1,0 +1,77 @@
+﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace R3.Tests;
+
+public class PropertyChangedExtensionsTest
+{
+    [Fact]
+    public void PropertyChanged()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .WhenChanged(nameof(ChangesProperty.Value), x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.Value = 1;
+
+        liveList.AssertEqual([0,1]);
+    }
+
+    [Fact]
+    public void PropertyChanging()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .WhenChanging(nameof(ChangesProperty.Value), x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.Value = 1;
+
+        liveList.AssertEqual([0,0]);
+    }
+
+    class ChangesProperty : INotifyPropertyChanged, INotifyPropertyChanging
+    {
+        private int _value;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
+
+        public int Value
+        {
+            get => _value;
+            set => SetField(ref _value, value);
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private void OnPropertyChanging([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+        }
+
+        private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            OnPropertyChanging(propertyName);
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+    }
+}


### PR DESCRIPTION
Introduced two new extension methods for INotifyPropertyChanged and INotifyPropertyChanging interfaces. These methods create an observable sequence that emits a value when the specified property changes or is changing, respectively. The current value of the property is always emitted upon subscription. Also added corresponding unit tests to verify these new functionalities. 

This is helpful for UI platforms like MAUI, Avalonia, WinUI, and WPF where UI elements will raise change notifications when a value is updated or with view model objects that often implement the INotifyPropertyChanged/ing interfaces. The advantage of this over `EveryValueChanged` on these platforms is that the properties emit and do not require inspection when the frame advances.

These are similar to the implementations from https://github.com/reactivemarbles/PropertyChanged

In the future, it would be great to have Bindings for the platforms and support for Chained properties (e.g. `MyProperty.MySubProperty.Value`), but those are more like nice-to-have features and might require things like source generators for better performance.