### PR TITLE
Hide PlayerLoopTiming in Unity

### DIFF
--- a/src/R3.Unity/Assets/R3.Unity/Runtime/PlayerLoopHelper.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/PlayerLoopHelper.cs
@@ -24,7 +24,7 @@ namespace R3
         public struct TimeUpdate { };
     }
 
-    public enum PlayerLoopTiming
+    internal enum PlayerLoopTiming
     {
         Initialization = 0,
         EarlyUpdate = 1,

--- a/src/R3.Unity/Assets/R3.Unity/Runtime/UnityFrameProvider.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/UnityFrameProvider.cs
@@ -18,7 +18,7 @@ namespace R3
         FreeListCore<IFrameRunnerWorkItem> list;
         readonly object gate = new object();
 
-        public PlayerLoopTiming PlayerLoopTiming { get; }
+        internal PlayerLoopTiming PlayerLoopTiming { get; }
 
         internal UnityFrameProvider(PlayerLoopTiming playerLoopTiming)
         {


### PR DESCRIPTION
It conflicts with UniTask so hide it..