### PR TITLE
add read-only variation of BindableReactiveProperty and its tests

### DIFF
--- a/sandbox/WpfApp1/MainWindow.xaml
+++ b/sandbox/WpfApp1/MainWindow.xaml
@@ -7,17 +7,21 @@
         mc:Ignorable="d"
         Title="MainWindow" Height="450" Width="800">
     <Window.DataContext>
-        <!--<local:BasicUsagesViewModel />-->
-        <!--<local:ValidationViewModel />-->
-        <local:CommandViewModel />
+        <local:BasicUsagesViewModel />
+        <!--<local:ValidationViewModel />
+        <local:CommandViewModel />-->
     </Window.DataContext>
-    <!--<StackPanel>
+    <StackPanel>
         <TextBlock Text="Basic usages" FontSize="24" />
         <Label Content="Input" />
         <TextBox Text="{Binding Input.Value, UpdateSourceTrigger=PropertyChanged}" />
-        <Label Content="Output" />
+        <Label Content="BindableReactiveProperty.Value" />
         <TextBlock Text="{Binding Output.Value}" />
-    </StackPanel>-->
+        <Label Content="ReadOnlyBindableReactiveProperty.CurrentValue" />
+        <TextBlock Text="{Binding OutputRO.CurrentValue}" />
+        <TextBlock Text="{Binding OutputRO2.CurrentValue}" />
+        <Button Content="add" Command="{Binding AddCommand}" />
+    </StackPanel>
 
     <!--<StackPanel Margin="10">
         <Label Content="Validation" />
@@ -28,9 +32,9 @@
     </StackPanel>-->
 
 
-    <StackPanel Margin="10">
+    <!--<StackPanel Margin="10">
         <Label Content="Command" />
         <CheckBox IsChecked="{Binding OnCheck.Value}" />
         <Button Content="Btn" Command="{Binding ShowMessageBox}" />
-    </StackPanel>
+    </StackPanel>-->
 </Window>

--- a/sandbox/WpfApp1/MainWindow.xaml
+++ b/sandbox/WpfApp1/MainWindow.xaml
@@ -16,10 +16,12 @@
         <Label Content="Input" />
         <TextBox Text="{Binding Input.Value, UpdateSourceTrigger=PropertyChanged}" />
         <Label Content="BindableReactiveProperty.Value" />
-        <TextBlock Text="{Binding Output.Value}" />
+        <TextBlock Text="{Binding Output.Value}" Margin="40 0" />
         <Label Content="ReadOnlyBindableReactiveProperty.CurrentValue" />
-        <TextBlock Text="{Binding OutputRO.CurrentValue}" />
-        <TextBlock Text="{Binding OutputRO2.CurrentValue}" />
+        <Label Content="from BindableReactiveProperty" Margin="20 0" />
+        <TextBlock Text="{Binding OutputRO.CurrentValue}" Margin="40 0" />
+        <Label Content="from ReadOnlyReactiveProperty" Margin="20 0" />
+        <TextBlock Text="{Binding OutputRO2.CurrentValue}" Margin="40 0" />
         <Button Content="add" Command="{Binding AddCommand}" />
     </StackPanel>
 

--- a/sandbox/WpfApp1/MainWindow.xaml.cs
+++ b/sandbox/WpfApp1/MainWindow.xaml.cs
@@ -59,11 +59,26 @@ public class BasicUsagesViewModel : IDisposable
 {
     public BindableReactiveProperty<string> Input { get; }
     public BindableReactiveProperty<string> Output { get; }
+    public ReadOnlyBindableReactiveProperty<string> OutputRO { get; }
+    public ReadOnlyBindableReactiveProperty<string> OutputRO2 { get; }
+    public ReactiveCommand<Unit> AddCommand { get; } = new();
 
     public BasicUsagesViewModel()
     {
         Input = new BindableReactiveProperty<string>("");
         Output = Input.Select(x => x.ToUpper()).ToBindableReactiveProperty("");
+        var rrp = Input.ToReadOnlyReactiveProperty("");
+        OutputRO = Input.ToReadOnlyBindableReactiveProperty("");
+        OutputRO2 = rrp.ToReadOnlyBindableReactiveProperty("");
+        AddCommand.SubscribeAwait(async (_, _) =>
+        {
+            var i = 0;
+            while (i++ < 10)
+            {
+                Input.Value += "@";
+                await Task.Delay(500);
+            }
+        });
     }
 
     public void Dispose()

--- a/src/R3/BindableReactiveProperty.cs
+++ b/src/R3/BindableReactiveProperty.cs
@@ -144,8 +144,12 @@ public class BindableReactiveProperty<T> : ReadOnlyBindableReactiveProperty<T>, 
 
                 if (!validationContext.TryValidateValue(value, errors))
                 {
-                    ErrorsChanged?.Invoke(this, ValueChangedEventArgs.GetDataErrorsChangedEventArgs(isReadOnly));
-
+                    // need both, even if read-only; because read-only instance by this.ToReadOnlyBindableReactiveProperty() is just a cast with side-effect
+                    ErrorsChanged?.Invoke(this, ValueChangedEventArgs.DataErrorsChanged);
+                    if (isReadOnly)
+                    {
+                        ErrorsChanged?.Invoke(this, ValueChangedEventArgs.DataErrorsChangedReadOnly);
+                    }
                     // set is completed(validation does not call before set) so continue call PropertyChanged
                 }
             }
@@ -163,12 +167,22 @@ public class BindableReactiveProperty<T> : ReadOnlyBindableReactiveProperty<T>, 
                 if (errors != null && errors.Count != 0)
                 {
                     errors.Clear();
-                    ErrorsChanged?.Invoke(this, ValueChangedEventArgs.GetDataErrorsChangedEventArgs(isReadOnly));
+                    // need both, even if read-only; because read-only instance by this.ToReadOnlyBindableReactiveProperty() is just a cast with side-effect
+                    ErrorsChanged?.Invoke(this, ValueChangedEventArgs.DataErrorsChanged);
+                    if (isReadOnly)
+                    {
+                        ErrorsChanged?.Invoke(this, ValueChangedEventArgs.DataErrorsChangedReadOnly);
+                    }
                 }
             }
         }
 
-        PropertyChanged?.Invoke(this, ValueChangedEventArgs.GetPropertyChangedEventArgs(isReadOnly));
+        // need both, even if read-only; because read-only instance by this.ToReadOnlyBindableReactiveProperty() is just a cast with side-effect
+        PropertyChanged?.Invoke(this, ValueChangedEventArgs.PropertyChanged);
+        if (isReadOnly)
+        {
+            PropertyChanged?.Invoke(this, ValueChangedEventArgs.PropertyChangedReadOnly);
+        }
     }
 
     // for INotifyDataErrorInfo
@@ -226,7 +240,12 @@ public class BindableReactiveProperty<T> : ReadOnlyBindableReactiveProperty<T>, 
             errors.Add(new ValidationResult(exception.Message));
         }
 
-        ErrorsChanged?.Invoke(this, ValueChangedEventArgs.GetDataErrorsChangedEventArgs(isReadOnly));
+        // need both, even if read-only; because read-only instance by this.ToReadOnlyBindableReactiveProperty() is just a cast with side-effect
+        ErrorsChanged?.Invoke(this, ValueChangedEventArgs.DataErrorsChanged);
+        if (isReadOnly)
+        {
+            ErrorsChanged?.Invoke(this, ValueChangedEventArgs.DataErrorsChangedReadOnly);
+        }
     }
 
     public BindableReactiveProperty<T> EnableValidation()
@@ -315,11 +334,8 @@ internal sealed class PropertyValidationContext(ValidationContext context, Valid
 
 internal static class ValueChangedEventArgs
 {
-    static readonly PropertyChangedEventArgs propertyChanged = new PropertyChangedEventArgs("Value");
-    static readonly PropertyChangedEventArgs propertyChangedReadOnly = new PropertyChangedEventArgs("CurrentValue");
-    static readonly DataErrorsChangedEventArgs dataErrorsChanged = new DataErrorsChangedEventArgs("Value");
-    static readonly DataErrorsChangedEventArgs dataErrorsChangedReadOnly = new DataErrorsChangedEventArgs("CurrentValue");
-
-    internal static PropertyChangedEventArgs GetPropertyChangedEventArgs(bool isReadOnly) => isReadOnly ? propertyChangedReadOnly : propertyChanged;
-    internal static DataErrorsChangedEventArgs GetDataErrorsChangedEventArgs(bool isReadOnly) => isReadOnly ? dataErrorsChangedReadOnly : dataErrorsChanged;
+    internal static readonly PropertyChangedEventArgs PropertyChanged = new PropertyChangedEventArgs("Value");
+    internal static readonly PropertyChangedEventArgs PropertyChangedReadOnly = new PropertyChangedEventArgs("CurrentValue");
+    internal static readonly DataErrorsChangedEventArgs DataErrorsChanged = new DataErrorsChangedEventArgs("Value");
+    internal static readonly DataErrorsChangedEventArgs DataErrorsChangedReadOnly = new DataErrorsChangedEventArgs("CurrentValue");
 }

--- a/src/R3/ReactiveProperty.cs
+++ b/src/R3/ReactiveProperty.cs
@@ -22,17 +22,6 @@ public abstract class ReadOnlyReactiveProperty<T> : Observable<T>, IDisposable
 #endif
 public class ReactiveProperty<T> : ReactivePropertyBase<T>
 {
-    T currentValue;
-    IEqualityComparer<T>? equalityComparer;
-    FreeListCore<Subscription> list; // struct(array, int)
-    CompleteState completeState;     // struct(int, IntPtr)
-
-    public IEqualityComparer<T>? EqualityComparer => equalityComparer;
-
-    public override T CurrentValue => currentValue;
-
-    public bool IsDisposed => completeState.IsDisposed;
-
     public T Value
     {
         get => this.currentValue;
@@ -82,9 +71,8 @@ public class ReactivePropertyBase<T> : ReadOnlyReactiveProperty<T>, ISubject<T>
 {
     protected T currentValue;
     IEqualityComparer<T>? equalityComparer;
-    FreeListCore<Subscription> list; // struct(array, int)
-    CompleteState completeState;     // struct(int, IntPtr)
     ObserverNode? root; // Root of LinkedList Node(Root.Previous is Last)
+    CompleteState completeState;     // struct(int, IntPtr)
 
     public IEqualityComparer<T>? EqualityComparer => equalityComparer;
 

--- a/src/R3/ReactivePropertyExtensions.cs
+++ b/src/R3/ReactivePropertyExtensions.cs
@@ -29,6 +29,25 @@ public static class ReactivePropertyExtensions
     {
         return new BindableReactiveProperty<T>(source, initialValue, equalityComparer);
     }
+
+    public static ReadOnlyBindableReactiveProperty<T> ToReadOnlyBindableReactiveProperty<T>(this Observable<T> source, T initialValue = default!)
+    {
+        if (source is ReadOnlyBindableReactiveProperty<T> rrp)
+        {
+            return rrp;
+        }
+        return source.ToReadOnlyBindableReactiveProperty(EqualityComparer<T>.Default, initialValue);
+    }
+
+    public static ReadOnlyBindableReactiveProperty<T> ToReadOnlyBindableReactiveProperty<T>(this Observable<T> source, IEqualityComparer<T>? equalityComparer, T initialValue = default!)
+    {
+        if (source is ReadOnlyBindableReactiveProperty<T> rrp)
+        {
+            return rrp;
+        }
+        // allow to cast ReactiveProperty<T>
+        return new ConnectedBindableReactiveProperty<T>(source, initialValue, equalityComparer);
+    }
 }
 
 internal sealed class ConnectedReactiveProperty<T> : ReactiveProperty<T>
@@ -64,3 +83,38 @@ internal sealed class ConnectedReactiveProperty<T> : ReactiveProperty<T>
         }
     }
 }
+
+internal sealed class ConnectedBindableReactiveProperty<T> : BindableReactiveProperty<T>
+{
+    readonly IDisposable sourceSubscription;
+
+    public ConnectedBindableReactiveProperty(Observable<T> source, T initialValue, IEqualityComparer<T>? equalityComparer)
+        : base(initialValue, equalityComparer)
+    {
+        this.sourceSubscription = source.Subscribe(new Observer(this));
+    }
+
+    protected override void DisposeCore()
+    {
+        sourceSubscription.Dispose();
+    }
+
+    class Observer(ConnectedBindableReactiveProperty<T> parent) : Observer<T>
+    {
+        protected override void OnNextCore(T value)
+        {
+            parent.Value = value;
+        }
+
+        protected override void OnErrorResumeCore(Exception error)
+        {
+            parent.OnErrorResume(error);
+        }
+
+        protected override void OnCompletedCore(Result result)
+        {
+            parent.OnCompleted(result);
+        }
+    }
+}
+

--- a/src/R3/ReactivePropertyExtensions.cs
+++ b/src/R3/ReactivePropertyExtensions.cs
@@ -32,21 +32,13 @@ public static class ReactivePropertyExtensions
 
     public static ReadOnlyBindableReactiveProperty<T> ToReadOnlyBindableReactiveProperty<T>(this Observable<T> source, T initialValue = default!)
     {
-        if (source is ReadOnlyBindableReactiveProperty<T> rrp)
-        {
-            return rrp;
-        }
         return source.ToReadOnlyBindableReactiveProperty(EqualityComparer<T>.Default, initialValue);
     }
 
     public static ReadOnlyBindableReactiveProperty<T> ToReadOnlyBindableReactiveProperty<T>(this Observable<T> source, IEqualityComparer<T>? equalityComparer, T initialValue = default!)
     {
-        if (source is ReadOnlyBindableReactiveProperty<T> rrp)
-        {
-            return rrp;
-        }
-        // allow to cast ReactiveProperty<T>
-        return new ConnectedBindableReactiveProperty<T>(source, initialValue, equalityComparer);
+        // allow to cast BindableReactiveProperty<T>
+        return new ConnectedBindableReactiveProperty<T>(source, initialValue, equalityComparer, isReadOnly: true);
     }
 }
 
@@ -88,8 +80,8 @@ internal sealed class ConnectedBindableReactiveProperty<T> : BindableReactivePro
 {
     readonly IDisposable sourceSubscription;
 
-    public ConnectedBindableReactiveProperty(Observable<T> source, T initialValue, IEqualityComparer<T>? equalityComparer)
-        : base(initialValue, equalityComparer)
+    public ConnectedBindableReactiveProperty(Observable<T> source, T initialValue, IEqualityComparer<T>? equalityComparer, bool isReadOnly = false)
+        : base(initialValue, equalityComparer, isReadOnly)
     {
         this.sourceSubscription = source.Subscribe(new Observer(this));
     }

--- a/tests/R3.Tests/BindableReactivePropertyTest.cs
+++ b/tests/R3.Tests/BindableReactivePropertyTest.cs
@@ -1,0 +1,100 @@
+﻿using System.Text.Json;
+
+namespace R3.Tests;
+
+public class BindableReactivePropertyTest
+{
+    [Fact]
+    public void Test()
+    {
+        var rp = new ReactiveProperty<int>(100);
+        var brp = rp.ToBindableReactiveProperty();
+
+        var list = brp.ToLiveList();
+        list.AssertEqual([100]);
+
+        rp.Value = 9999;
+
+        var list2 = brp.ToLiveList();
+        list.AssertEqual([100, 9999]);
+        list2.AssertEqual([9999]);
+
+        rp.Value = 9999;
+        list.AssertEqual([100, 9999]);
+        list2.AssertEqual([9999]);
+
+        rp.Value = 100;
+        list.AssertEqual([100, 9999, 100]);
+        list2.AssertEqual([9999, 100]);
+
+        rp.Dispose();
+
+        list.AssertIsCompleted();
+        list2.AssertIsCompleted();
+    }
+
+    [Fact]
+    public void ReadOnlyTest()
+    {
+        var rp = new ReactiveProperty<int>(100);
+        var rorp = rp.ToReadOnlyReactiveProperty();
+        var brp0 = rp.ToReadOnlyBindableReactiveProperty();
+        var brp1 = rorp.ToReadOnlyBindableReactiveProperty();
+
+        brp0.CurrentValue.Should().Be(100);
+        brp1.CurrentValue.Should().Be(100);
+        var list0 = brp0.ToLiveList();
+        var list1 = brp1.ToLiveList();
+        list0.AssertEqual([100]);
+        list1.AssertEqual([100]);
+
+        rp.Value = 9999;
+
+        brp0.CurrentValue.Should().Be(9999);
+        brp1.CurrentValue.Should().Be(9999);
+        list0.AssertEqual([100, 9999]);
+        list1.AssertEqual([100, 9999]);
+
+        rp.Dispose();
+        list0.AssertIsCompleted();
+        list1.AssertIsCompleted();
+    }
+
+    [Fact]
+    public void DefaultValueTest()
+    {
+        using var rp = new ReactiveProperty<int>();
+        var brp0 = rp.ToBindableReactiveProperty();
+        var brp1 = rp.ToReadOnlyBindableReactiveProperty();
+        brp0.Value.Should().Be(default);
+        brp1.CurrentValue.Should().Be(default);
+    }
+
+    [Fact]
+    public void SubscribeAfterCompleted()
+    {
+        var rp = new ReactiveProperty<string>("foo");
+        var brp0 = rp.ToBindableReactiveProperty();
+        var brp1 = rp.ToReadOnlyBindableReactiveProperty();
+        rp.OnCompleted();
+
+        using var list0 = brp0.ToLiveList();
+        using var list1 = brp1.ToLiveList();
+
+        list0.AssertIsCompleted();
+        list0.AssertEqual(["foo"]);
+        list1.AssertIsCompleted();
+        list1.AssertEqual(["foo"]);
+    }
+
+    [Fact]
+    public void SerializeTest()
+    {
+        var rp = new ReactiveProperty<string>("foo");
+        var brp0 = rp.ToBindableReactiveProperty("");
+        var brp1 = rp.ToReadOnlyBindableReactiveProperty("");
+
+        JsonSerializer.Serialize(brp0).Should().Be("\"foo\"");
+        JsonSerializer.Serialize(brp1).Should().Be("""{"EqualityComparer":{},"CurrentValue":"foo","IsDisposed":false}""");
+    }
+}

--- a/tests/R3.Tests/ReactivePropertyTest.cs
+++ b/tests/R3.Tests/ReactivePropertyTest.cs
@@ -1,4 +1,6 @@
-﻿namespace R3.Tests;
+﻿using System.Text.Json;
+
+namespace R3.Tests;
 
 public class ReactivePropertyTest
 {
@@ -48,5 +50,14 @@ public class ReactivePropertyTest
 
         list.AssertIsCompleted();
         list.AssertEqual(["foo"]);
+    }
+
+    [Fact]
+    public void SerializeTest()
+    {
+        var rp = new ReactiveProperty<string>("foo");
+        var rrp = rp.ToReadOnlyReactiveProperty("");
+        JsonSerializer.Serialize(rp).Should().Be("\"foo\"");
+        JsonSerializer.Serialize(rrp).Should().Be("""{"CurrentValue":"foo"}""");
     }
 }


### PR DESCRIPTION
- Change `ReactiveProperty` source to add read-only `BindableReactiveProperty`.
  - Create `ReactivePropertyBase` as shared base, which excludes the `Value { get; set; }` from `ReactiveProperty`.
  - `ReadOnlyBindableReactiveProperty` itself doesn't implement `Value { get; set; }`, but `{Binding SomeReadOnlyBindableReactiveProperty.Value}` in xaml works through its entity `BindableReactiveProperty`.
- Naming convension
  - `ReadOnlyBindableReactiveProperty`? `BindableReadOnlyReactiveProperty`?
  - `ReactivePropertyBase` seems unclear and too simple, but I don't have better one.
- Json serialization results as expected like existing ReactiveProperty ones, but deserialization may not.