### PR TITLE
First pass at observing nested property changes

### DIFF
--- a/src/R3/Factories/ObserveProperty.cs
+++ b/src/R3/Factories/ObserveProperty.cs
@@ -13,7 +13,7 @@ public static partial class Observable
         Func<T, TProperty> propertySelector,
         bool pushCurrentValueOnSubscribe = true,
         CancellationToken cancellationToken = default,
-        [CallerArgumentExpression("propertySelector")] string? expr = null)
+        [CallerArgumentExpression(nameof(propertySelector))] string? expr = null)
         where T : INotifyPropertyChanged
     {
         if (expr == null) throw new ArgumentNullException(expr);
@@ -23,6 +23,37 @@ public static partial class Observable
     }
 
     /// <summary>
+    /// Convert INotifyPropertyChanged to Observable.
+    /// `propertySelector` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
+    /// </summary>
+    public static Observable<TProperty2> ObservePropertyChanged<T, TProperty1, TProperty2>(this T value,
+        Func<T, TProperty1> propertySelector1,
+        Func<TProperty1, TProperty2> propertySelector2,
+        bool pushCurrentValueOnSubscribe = true,
+        CancellationToken cancellationToken = default,
+        [CallerArgumentExpression(nameof(propertySelector1))] string? propertySelector1Expr = null,
+        [CallerArgumentExpression(nameof(propertySelector2))] string? propertySelector2Expr = null)
+        where T : INotifyPropertyChanged
+        where TProperty1 : INotifyPropertyChanged
+    {
+        if (propertySelector1Expr == null) throw new ArgumentNullException(propertySelector1Expr);
+        if (propertySelector2Expr == null) throw new ArgumentNullException(propertySelector2Expr);
+
+        var property1Name = propertySelector1Expr!.Substring(propertySelector1Expr.LastIndexOf('.') + 1);
+        var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
+
+        var firstPropertyChanged = new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, pushCurrentValueOnSubscribe, cancellationToken);
+
+        return firstPropertyChanged
+            .Select(
+                (propertySelector2, property2Name, pushCurrentValueOnSubscribe, cancellationToken),
+                (firstPropertyValue, state) =>
+                    (Observable<TProperty2>)new ObservePropertyChanged<TProperty1, TProperty2>(firstPropertyValue, state.propertySelector2, state.property2Name, state.pushCurrentValueOnSubscribe, state.cancellationToken))
+            .Switch();
+    }
+
+
+    /// <summary>
     /// Convert INotifyPropertyChanging to Observable.
     /// `propertySelector` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
     /// </summary>
@@ -30,7 +61,7 @@ public static partial class Observable
         Func<T, TProperty> propertySelector,
         bool pushCurrentValueOnSubscribe = true,
         CancellationToken cancellationToken = default,
-        [CallerArgumentExpression("propertySelector")] string? expr = null)
+        [CallerArgumentExpression(nameof(propertySelector))] string? expr = null)
         where T : INotifyPropertyChanging
     {
         if (expr == null) throw new ArgumentNullException(expr);

--- a/src/R3/Factories/ObserveProperty.cs
+++ b/src/R3/Factories/ObserveProperty.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace R3;
@@ -24,7 +24,7 @@ public static partial class Observable
 
     /// <summary>
     /// Convert INotifyPropertyChanged to Observable.
-    /// `propertySelector` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
+    /// `propertySelector1` and `propertySelector2` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
     /// </summary>
     public static Observable<TProperty2> ObservePropertyChanged<T, TProperty1, TProperty2>(this T value,
         Func<T, TProperty1> propertySelector1,
@@ -42,16 +42,61 @@ public static partial class Observable
         var property1Name = propertySelector1Expr!.Substring(propertySelector1Expr.LastIndexOf('.') + 1);
         var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
 
-        var firstPropertyChanged = new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, pushCurrentValueOnSubscribe, cancellationToken);
-
-        return firstPropertyChanged
+        return new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, true, cancellationToken)
             .Select(
                 (propertySelector2, property2Name, pushCurrentValueOnSubscribe, cancellationToken),
                 (firstPropertyValue, state) =>
-                    (Observable<TProperty2>)new ObservePropertyChanged<TProperty1, TProperty2>(firstPropertyValue, state.propertySelector2, state.property2Name, state.pushCurrentValueOnSubscribe, state.cancellationToken))
+                    firstPropertyValue is not null
+                        ? new ObservePropertyChanged<TProperty1, TProperty2>(firstPropertyValue,
+                            state.propertySelector2, state.property2Name, state.pushCurrentValueOnSubscribe,
+                            state.cancellationToken)
+                        : Empty<TProperty2>())
             .Switch();
     }
 
+    /// <summary>
+    /// Convert INotifyPropertyChanged to Observable.
+    /// `propertySelector1`, `propertySelector2`, and `propertySelector3` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
+    /// </summary>
+    public static Observable<TProperty3> ObservePropertyChanged<T, TProperty1, TProperty2, TProperty3>(this T value,
+        Func<T, TProperty1> propertySelector1,
+        Func<TProperty1, TProperty2> propertySelector2,
+        Func<TProperty2, TProperty3> propertySelector3,
+        bool pushCurrentValueOnSubscribe = true,
+        CancellationToken cancellationToken = default,
+        [CallerArgumentExpression(nameof(propertySelector1))] string? propertySelector1Expr = null,
+        [CallerArgumentExpression(nameof(propertySelector2))] string? propertySelector2Expr = null,
+        [CallerArgumentExpression(nameof(propertySelector3))] string? propertySelector3Expr = null)
+        where T : INotifyPropertyChanged
+        where TProperty1 : INotifyPropertyChanged
+        where TProperty2 : INotifyPropertyChanged
+    {
+        if (propertySelector1Expr == null) throw new ArgumentNullException(propertySelector1Expr);
+        if (propertySelector2Expr == null) throw new ArgumentNullException(propertySelector2Expr);
+        if (propertySelector3Expr == null) throw new ArgumentNullException(propertySelector3Expr);
+
+        var property1Name = propertySelector1Expr!.Substring(propertySelector1Expr.LastIndexOf('.') + 1);
+        var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
+        var property3Name = propertySelector3Expr!.Substring(propertySelector3Expr.LastIndexOf('.') + 1);
+
+        return new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, true, cancellationToken)
+            .Select(
+                (propertySelector2, property2Name, propertySelector3, property3Name, pushCurrentValueOnSubscribe, cancellationToken),
+                (firstPropertyValue, state) =>
+                    firstPropertyValue is not null
+                        ? new ObservePropertyChanged<TProperty1, TProperty2>(firstPropertyValue, state.propertySelector2, state.property2Name, true, state.cancellationToken)
+                            .Select(
+                                (state.propertySelector3, state.property3Name, pushCurrentValueOnSubscribe, cancellationToken),
+                                (secondPropertyValue, state2) =>
+                                    secondPropertyValue is not null
+                                        ? new ObservePropertyChanged<TProperty2, TProperty3>(secondPropertyValue,
+                                            state2.propertySelector3, state2.property3Name, state2.pushCurrentValueOnSubscribe,
+                                            state2.cancellationToken)
+                                        : Empty<TProperty3>())
+                            .Switch()
+                        : Empty<TProperty3>())
+            .Switch();
+    }
 
     /// <summary>
     /// Convert INotifyPropertyChanging to Observable.
@@ -67,11 +112,95 @@ public static partial class Observable
         if (expr == null) throw new ArgumentNullException(expr);
 
         var propertyName = expr!.Substring(expr.LastIndexOf('.') + 1);
-        return new ObservePropertyChanging<T, TProperty>(value, propertySelector, propertyName, pushCurrentValueOnSubscribe, cancellationToken);
+        return new ObservePropertyChanging<T, TProperty>(value, propertySelector, propertyName,
+            pushCurrentValueOnSubscribe, cancellationToken);
+    }
+
+    /// <summary>
+    /// Convert INotifyPropertyChanging to Observable.
+    /// `propertySelector1` and `propertySelector2` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
+    /// </summary>
+    public static Observable<TProperty2> ObservePropertyChanging<T, TProperty1, TProperty2>(this T value,
+        Func<T, TProperty1> propertySelector1,
+        Func<TProperty1, TProperty2> propertySelector2,
+        bool pushCurrentValueOnSubscribe = true,
+        CancellationToken cancellationToken = default,
+        [CallerArgumentExpression(nameof(propertySelector1))] string? propertySelector1Expr = null,
+        [CallerArgumentExpression(nameof(propertySelector2))] string? propertySelector2Expr = null)
+        where T : INotifyPropertyChanged
+        where TProperty1 : INotifyPropertyChanging
+    {
+        if (propertySelector1Expr == null) throw new ArgumentNullException(propertySelector1Expr);
+        if (propertySelector2Expr == null) throw new ArgumentNullException(propertySelector2Expr);
+
+        var property1Name = propertySelector1Expr!.Substring(propertySelector1Expr.LastIndexOf('.') + 1);
+        var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
+
+
+        return new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, true, cancellationToken)
+            .Select(
+                (propertySelector2, property2Name, pushCurrentValueOnSubscribe, cancellationToken),
+                (firstPropertyValue, state) =>
+                    firstPropertyValue is not null
+                        ? new ObservePropertyChanging<TProperty1, TProperty2>(firstPropertyValue,
+                            state.propertySelector2, state.property2Name, state.pushCurrentValueOnSubscribe,
+                            state.cancellationToken)
+                        : Empty<TProperty2>())
+            .Switch();
+    }
+
+    /// <summary>
+    /// Convert INotifyPropertyChanging to Observable.
+    /// `propertySelector1`, `propertySelector2`, and `propertySelector3` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
+    /// </summary>
+    public static Observable<TProperty3> ObservePropertyChanging<T, TProperty1, TProperty2, TProperty3>(this T value,
+        Func<T, TProperty1> propertySelector1,
+        Func<TProperty1, TProperty2> propertySelector2,
+        Func<TProperty2, TProperty3> propertySelector3,
+        bool pushCurrentValueOnSubscribe = true,
+        CancellationToken cancellationToken = default,
+        [CallerArgumentExpression(nameof(propertySelector1))] string? propertySelector1Expr = null,
+        [CallerArgumentExpression(nameof(propertySelector2))] string? propertySelector2Expr = null,
+        [CallerArgumentExpression(nameof(propertySelector3))] string? propertySelector3Expr = null)
+        where T : INotifyPropertyChanged
+        where TProperty1 : INotifyPropertyChanged
+        where TProperty2 : INotifyPropertyChanging
+    {
+        if (propertySelector1Expr == null) throw new ArgumentNullException(propertySelector1Expr);
+        if (propertySelector2Expr == null) throw new ArgumentNullException(propertySelector2Expr);
+        if (propertySelector3Expr == null) throw new ArgumentNullException(propertySelector3Expr);
+
+        var property1Name = propertySelector1Expr!.Substring(propertySelector1Expr.LastIndexOf('.') + 1);
+        var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
+        var property3Name = propertySelector3Expr!.Substring(propertySelector3Expr.LastIndexOf('.') + 1);
+
+        return new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, pushCurrentValueOnSubscribe, cancellationToken)
+            .Select(
+                (propertySelector2, property2Name, propertySelector3, property3Name, pushCurrentValueOnSubscribe, cancellationToken),
+                (firstPropertyValue, state) =>
+                    (firstPropertyValue is not null
+                        ? new ObservePropertyChanged<TProperty1, TProperty2>(
+                                firstPropertyValue, state.propertySelector2, state.property2Name, true, state.cancellationToken)
+                            .Select(
+                                (state.propertySelector3, state.property3Name, pushCurrentValueOnSubscribe, cancellationToken),
+                                (secondPropertyValue, state2) =>
+                                    secondPropertyValue is not null
+                                        ? new ObservePropertyChanging<TProperty2, TProperty3>(secondPropertyValue,
+                                            state2.propertySelector3, state2.property3Name, state2.pushCurrentValueOnSubscribe,
+                                            state2.cancellationToken)
+                                        : Empty<TProperty3>())
+                            .Switch()
+                        : Empty<TProperty3>()))
+            .Switch();
     }
 }
 
-internal sealed class ObservePropertyChanged<T, TProperty>(T value, Func<T, TProperty> propertySelector, string propertyName, bool pushCurrentValueOnSubscribe, CancellationToken cancellationToken)
+internal sealed class ObservePropertyChanged<T, TProperty>(
+    T value,
+    Func<T, TProperty> propertySelector,
+    string propertyName,
+    bool pushCurrentValueOnSubscribe,
+    CancellationToken cancellationToken)
     : Observable<TProperty> where T : INotifyPropertyChanged
 {
     protected override IDisposable SubscribeCore(Observer<TProperty> observer)
@@ -150,7 +279,12 @@ internal sealed class ObservePropertyChanged<T, TProperty>(T value, Func<T, TPro
     }
 }
 
-internal sealed class ObservePropertyChanging<T, TProperty>(T value, Func<T, TProperty> propertySelector, string propertyName, bool pushCurrentValueOnSubscribe, CancellationToken cancellationToken)
+internal sealed class ObservePropertyChanging<T, TProperty>(
+    T value,
+    Func<T, TProperty> propertySelector,
+    string propertyName,
+    bool pushCurrentValueOnSubscribe,
+    CancellationToken cancellationToken)
     : Observable<TProperty> where T : INotifyPropertyChanging
 {
     protected override IDisposable SubscribeCore(Observer<TProperty> observer)
@@ -160,10 +294,10 @@ internal sealed class ObservePropertyChanging<T, TProperty>(T value, Func<T, TPr
             observer.OnNext(propertySelector(value));
         }
 
-        return new _ObservePropertyChanged(observer, value, propertySelector, propertyName, cancellationToken);
+        return new _ObservePropertyChanging(observer, value, propertySelector, propertyName, cancellationToken);
     }
 
-    sealed class _ObservePropertyChanged : IDisposable
+    sealed class _ObservePropertyChanging : IDisposable
     {
         readonly Observer<TProperty> observer;
         readonly T value;
@@ -172,7 +306,7 @@ internal sealed class ObservePropertyChanging<T, TProperty>(T value, Func<T, TPr
         PropertyChangingEventHandler? eventHandler;
         CancellationTokenRegistration cancellationTokenRegistration;
 
-        public _ObservePropertyChanged(Observer<TProperty> observer, T value, Func<T, TProperty> propertySelector, string propertyName, CancellationToken cancellationToken)
+        public _ObservePropertyChanging(Observer<TProperty> observer, T value, Func<T, TProperty> propertySelector, string propertyName, CancellationToken cancellationToken)
         {
             this.observer = observer;
             this.value = value;
@@ -186,7 +320,7 @@ internal sealed class ObservePropertyChanging<T, TProperty>(T value, Func<T, TPr
             {
                 this.cancellationTokenRegistration = cancellationToken.UnsafeRegister(static state =>
                 {
-                    var s = (_ObservePropertyChanged)state!;
+                    var s = (_ObservePropertyChanging)state!;
                     s.CompleteDispose();
                 }, this);
             }

--- a/src/R3/Factories/ObserveProperty.cs
+++ b/src/R3/Factories/ObserveProperty.cs
@@ -130,14 +130,11 @@ public static partial class Observable
         where T : INotifyPropertyChanged
         where TProperty1 : INotifyPropertyChanging
     {
-        if (propertySelector1Expr == null) throw new ArgumentNullException(propertySelector1Expr);
         if (propertySelector2Expr == null) throw new ArgumentNullException(propertySelector2Expr);
 
-        var property1Name = propertySelector1Expr!.Substring(propertySelector1Expr.LastIndexOf('.') + 1);
         var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
 
-
-        return new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, true, cancellationToken)
+        return ObservePropertyChanged(value, propertySelector1, true, cancellationToken, propertySelector1Expr)
             .Select(
                 (propertySelector2, property2Name, pushCurrentValueOnSubscribe, cancellationToken),
                 (firstPropertyValue, state) =>
@@ -166,31 +163,19 @@ public static partial class Observable
         where TProperty1 : INotifyPropertyChanged
         where TProperty2 : INotifyPropertyChanging
     {
-        if (propertySelector1Expr == null) throw new ArgumentNullException(propertySelector1Expr);
-        if (propertySelector2Expr == null) throw new ArgumentNullException(propertySelector2Expr);
         if (propertySelector3Expr == null) throw new ArgumentNullException(propertySelector3Expr);
 
-        var property1Name = propertySelector1Expr!.Substring(propertySelector1Expr.LastIndexOf('.') + 1);
-        var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
         var property3Name = propertySelector3Expr!.Substring(propertySelector3Expr.LastIndexOf('.') + 1);
 
-        return new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, pushCurrentValueOnSubscribe, cancellationToken)
+        return ObservePropertyChanged(value, propertySelector1, propertySelector2, true, cancellationToken, propertySelector1Expr, propertySelector2Expr)
             .Select(
-                (propertySelector2, property2Name, propertySelector3, property3Name, pushCurrentValueOnSubscribe, cancellationToken),
-                (firstPropertyValue, state) =>
-                    (firstPropertyValue is not null
-                        ? new ObservePropertyChanged<TProperty1, TProperty2>(
-                                firstPropertyValue, state.propertySelector2, state.property2Name, true, state.cancellationToken)
-                            .Select(
-                                (state.propertySelector3, state.property3Name, pushCurrentValueOnSubscribe, cancellationToken),
-                                (secondPropertyValue, state2) =>
-                                    secondPropertyValue is not null
-                                        ? new ObservePropertyChanging<TProperty2, TProperty3>(secondPropertyValue,
-                                            state2.propertySelector3, state2.property3Name, state2.pushCurrentValueOnSubscribe,
-                                            state2.cancellationToken)
-                                        : Empty<TProperty3>())
-                            .Switch()
-                        : Empty<TProperty3>()))
+                (propertySelector3, property3Name, pushCurrentValueOnSubscribe, cancellationToken),
+                (secondPropertyValue, state) =>
+                    secondPropertyValue is not null
+                        ? new ObservePropertyChanging<TProperty2, TProperty3>(secondPropertyValue,
+                            state.propertySelector3, state.property3Name, state.pushCurrentValueOnSubscribe,
+                            state.cancellationToken)
+                        : Empty<TProperty3>())
             .Switch();
     }
 }

--- a/tests/R3.Tests/FactoryTests/ObservePropertyTest.cs
+++ b/tests/R3.Tests/FactoryTests/ObservePropertyTest.cs
@@ -39,6 +39,34 @@ public class ObservePropertyTest
         propertyChanger.InnerPropertyChanged.Value = 1;
 
         liveList.AssertEqual([0, 1]);
+
+        propertyChanger.InnerPropertyChanged.Value = 2;
+
+        liveList.AssertEqual([0, 1, 2]);
+    }
+
+    [Fact]
+    public void DoubleNestedPropertyChanged()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanged(x => x.InnerPropertyChanged, x => x.InnerPropertyChanged, x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.InnerPropertyChanged = new();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.InnerPropertyChanged.InnerPropertyChanged = new();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.InnerPropertyChanged.InnerPropertyChanged.Value = 1;
+
+        liveList.AssertEqual([0, 1]);
     }
 
     [Fact]
@@ -55,6 +83,58 @@ public class ObservePropertyTest
         propertyChanger.Value = 1;
 
         liveList.AssertEqual([0, 0]);
+    }
+
+    [Fact]
+    public void NestedPropertyChanging()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanging(x => x.InnerPropertyChanged, x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.InnerPropertyChanged = new();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.InnerPropertyChanged.Value = 1;
+
+        liveList.AssertEqual([0, 0]);
+
+        propertyChanger.InnerPropertyChanged.Value = 2;
+
+        liveList.AssertEqual([0, 0, 1]);
+    }
+
+    [Fact]
+    public void DoubleNestedPropertyChanging()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanging(x => x.InnerPropertyChanged, x => x.InnerPropertyChanged, x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.InnerPropertyChanged = new();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.InnerPropertyChanged.InnerPropertyChanged = new();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.InnerPropertyChanged.InnerPropertyChanged.Value = 1;
+
+        liveList.AssertEqual([0, 0]);
+
+        propertyChanger.InnerPropertyChanged.InnerPropertyChanged.Value = 2;
+
+        liveList.AssertEqual([0, 0, 1]);
     }
 
     class ChangesProperty : INotifyPropertyChanged, INotifyPropertyChanging

--- a/tests/R3.Tests/FactoryTests/ObservePropertyTest.cs
+++ b/tests/R3.Tests/FactoryTests/ObservePropertyTest.cs
@@ -22,6 +22,26 @@ public class ObservePropertyTest
     }
 
     [Fact]
+    public void NestedPropertyChanged()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanged(x => x.InnerPropertyChanged, x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.InnerPropertyChanged = new();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.InnerPropertyChanged.Value = 1;
+
+        liveList.AssertEqual([0, 1]);
+    }
+
+    [Fact]
     public void PropertyChanging()
     {
         ChangesProperty propertyChanger = new();
@@ -40,6 +60,7 @@ public class ObservePropertyTest
     class ChangesProperty : INotifyPropertyChanged, INotifyPropertyChanging
     {
         private int _value;
+        private ChangesProperty _innerPropertyChanged;
 
         public event PropertyChangedEventHandler? PropertyChanged;
         public event PropertyChangingEventHandler? PropertyChanging;
@@ -48,6 +69,12 @@ public class ObservePropertyTest
         {
             get => _value;
             set => SetField(ref _value, value);
+        }
+
+        public ChangesProperty InnerPropertyChanged
+        {
+            get => _innerPropertyChanged;
+            set => SetField(ref _innerPropertyChanged, value);
         }
 
         private void OnPropertyChanged([CallerMemberName] string? propertyName = null)


### PR DESCRIPTION
Added a new method to observe changes in nested properties of INotifyPropertyChanged objects. This allows for more granular observation of property changes, particularly useful when dealing with complex objects. Also updated the test suite to cover this new functionality.