### PR TITLE
Updated property selectors to handle nullable types

### DIFF
--- a/src/R3/Factories/ObserveProperty.cs
+++ b/src/R3/Factories/ObserveProperty.cs
@@ -27,7 +27,7 @@ public static partial class Observable
     /// `propertySelector1` and `propertySelector2` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
     /// </summary>
     public static Observable<TProperty2> ObservePropertyChanged<T, TProperty1, TProperty2>(this T value,
-        Func<T, TProperty1> propertySelector1,
+        Func<T, TProperty1?> propertySelector1,
         Func<TProperty1, TProperty2> propertySelector2,
         bool pushCurrentValueOnSubscribe = true,
         CancellationToken cancellationToken = default,
@@ -42,7 +42,7 @@ public static partial class Observable
         var property1Name = propertySelector1Expr!.Substring(propertySelector1Expr.LastIndexOf('.') + 1);
         var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
 
-        return new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, true, cancellationToken)
+        return new ObservePropertyChanged<T, TProperty1?>(value, propertySelector1, property1Name, true, cancellationToken)
             .Select(
                 (propertySelector2, property2Name, pushCurrentValueOnSubscribe, cancellationToken),
                 (firstPropertyValue, state) =>
@@ -59,8 +59,8 @@ public static partial class Observable
     /// `propertySelector1`, `propertySelector2`, and `propertySelector3` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
     /// </summary>
     public static Observable<TProperty3> ObservePropertyChanged<T, TProperty1, TProperty2, TProperty3>(this T value,
-        Func<T, TProperty1> propertySelector1,
-        Func<TProperty1, TProperty2> propertySelector2,
+        Func<T, TProperty1?> propertySelector1,
+        Func<TProperty1, TProperty2?> propertySelector2,
         Func<TProperty2, TProperty3> propertySelector3,
         bool pushCurrentValueOnSubscribe = true,
         CancellationToken cancellationToken = default,
@@ -79,12 +79,12 @@ public static partial class Observable
         var property2Name = propertySelector2Expr!.Substring(propertySelector2Expr.LastIndexOf('.') + 1);
         var property3Name = propertySelector3Expr!.Substring(propertySelector3Expr.LastIndexOf('.') + 1);
 
-        return new ObservePropertyChanged<T, TProperty1>(value, propertySelector1, property1Name, true, cancellationToken)
+        return new ObservePropertyChanged<T, TProperty1?>(value, propertySelector1, property1Name, true, cancellationToken)
             .Select(
                 (propertySelector2, property2Name, propertySelector3, property3Name, pushCurrentValueOnSubscribe, cancellationToken),
                 (firstPropertyValue, state) =>
                     firstPropertyValue is not null
-                        ? new ObservePropertyChanged<TProperty1, TProperty2>(firstPropertyValue, state.propertySelector2, state.property2Name, true, state.cancellationToken)
+                        ? new ObservePropertyChanged<TProperty1, TProperty2?>(firstPropertyValue, state.propertySelector2, state.property2Name, true, state.cancellationToken)
                             .Select(
                                 (state.propertySelector3, state.property3Name, pushCurrentValueOnSubscribe, cancellationToken),
                                 (secondPropertyValue, state2) =>
@@ -121,7 +121,7 @@ public static partial class Observable
     /// `propertySelector1` and `propertySelector2` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
     /// </summary>
     public static Observable<TProperty2> ObservePropertyChanging<T, TProperty1, TProperty2>(this T value,
-        Func<T, TProperty1> propertySelector1,
+        Func<T, TProperty1?> propertySelector1,
         Func<TProperty1, TProperty2> propertySelector2,
         bool pushCurrentValueOnSubscribe = true,
         CancellationToken cancellationToken = default,
@@ -151,8 +151,8 @@ public static partial class Observable
     /// `propertySelector1`, `propertySelector2`, and `propertySelector3` must be a Func specifying a simple property. For example, it extracts "Foo" from `x => x.Foo`.
     /// </summary>
     public static Observable<TProperty3> ObservePropertyChanging<T, TProperty1, TProperty2, TProperty3>(this T value,
-        Func<T, TProperty1> propertySelector1,
-        Func<TProperty1, TProperty2> propertySelector2,
+        Func<T, TProperty1?> propertySelector1,
+        Func<TProperty1, TProperty2?> propertySelector2,
         Func<TProperty2, TProperty3> propertySelector3,
         bool pushCurrentValueOnSubscribe = true,
         CancellationToken cancellationToken = default,

--- a/tests/R3.Tests/FactoryTests/ObservePropertyTest.cs
+++ b/tests/R3.Tests/FactoryTests/ObservePropertyTest.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace R3.Tests.FactoryTests;
@@ -19,6 +19,24 @@ public class ObservePropertyTest
         propertyChanger.Value = 1;
 
         liveList.AssertEqual([0, 1]);
+    }
+
+    [Fact]
+    public void NullablePropertyChanged()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanged(x => x.NullableInnerPropertyChanged)
+            .ToLiveList();
+
+        liveList.AssertEqual([null]);
+
+        var nipc = new ChangesProperty();
+
+        propertyChanger.NullableInnerPropertyChanged = nipc;
+
+        liveList.AssertEqual([null, nipc]);
     }
 
     [Fact]
@@ -46,6 +64,52 @@ public class ObservePropertyTest
     }
 
     [Fact]
+    public void NullableNestedPropertyChanged()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanged(x => x.NullableInnerPropertyChanged, x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.NullableInnerPropertyChanged.Value = 1;
+
+        liveList.AssertEqual([0, 1]);
+
+        propertyChanger.NullableInnerPropertyChanged.Value = 2;
+
+        liveList.AssertEqual([0, 1, 2]);
+    }
+
+    [Fact]
+    public void NullableNestedPropertyChangedWithNullableEndProperty()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanged(x => x.NullableInnerPropertyChanged, x => x.NullableInnerPropertyChanged)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([null]);
+
+        var nipc = new ChangesProperty();
+
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged = nipc;
+
+        liveList.AssertEqual([null, nipc]);
+    }
+
+    [Fact]
     public void DoubleNestedPropertyChanged()
     {
         ChangesProperty propertyChanger = new();
@@ -70,6 +134,55 @@ public class ObservePropertyTest
     }
 
     [Fact]
+    public void NullableDoubleNestedPropertyChanged()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanged(x => x.NullableInnerPropertyChanged, x => x.NullableInnerPropertyChanged, x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged.Value = 1;
+
+        liveList.AssertEqual([0, 1]);
+    }
+
+    [Fact]
+    public void NullableDoubleNestedPropertyChangedWithNullableEndProperty()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanged(x => x.NullableInnerPropertyChanged, x => x.NullableInnerPropertyChanged, x => x.NullableInnerPropertyChanged)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([null]);
+
+        var nipc = new ChangesProperty();
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged.NullableInnerPropertyChanged = nipc;
+
+        liveList.AssertEqual([null, nipc]);
+    }
+
+    [Fact]
     public void PropertyChanging()
     {
         ChangesProperty propertyChanger = new();
@@ -83,6 +196,28 @@ public class ObservePropertyTest
         propertyChanger.Value = 1;
 
         liveList.AssertEqual([0, 0]);
+    }
+
+    [Fact]
+    public void NullablePropertyChanging()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanging(x => x.NullableInnerPropertyChanged)
+            .ToLiveList();
+
+        liveList.AssertEqual([null]);
+
+        var nipc1 = new ChangesProperty();
+        propertyChanger.NullableInnerPropertyChanged = nipc1;
+
+        liveList.AssertEqual([null, null]);
+
+        var nipc2 = new ChangesProperty();
+        propertyChanger.NullableInnerPropertyChanged = nipc2;
+
+        liveList.AssertEqual([null, null, nipc1]);
     }
 
     [Fact]
@@ -107,6 +242,61 @@ public class ObservePropertyTest
         propertyChanger.InnerPropertyChanged.Value = 2;
 
         liveList.AssertEqual([0, 0, 1]);
+    }
+
+    [Fact]
+    public void NullableNestedPropertyChanging()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanging(x => x.NullableInnerPropertyChanged, x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.NullableInnerPropertyChanged.Value = 1;
+
+        liveList.AssertEqual([0, 0]);
+
+        propertyChanger.NullableInnerPropertyChanged.Value = 2;
+
+        liveList.AssertEqual([0, 0, 1]);
+    }
+
+    [Fact]
+    public void NullableNestedPropertyChangingWithNullableEndProperty()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanging(x => x.NullableInnerPropertyChanged, x => x.NullableInnerPropertyChanged)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([null]);
+
+        var nipc1 = new ChangesProperty();
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged = nipc1;
+
+        liveList.AssertEqual([null, null]);
+
+        var nipc2 = new ChangesProperty();
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged = nipc2;
+
+        liveList.AssertEqual([null, null, nipc1]);
+
+        var nipc3 = new ChangesProperty();
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged = nipc3;
+
+        liveList.AssertEqual([null, null, nipc1, nipc2]);
     }
 
     [Fact]
@@ -137,10 +327,69 @@ public class ObservePropertyTest
         liveList.AssertEqual([0, 0, 1]);
     }
 
+    [Fact]
+    public void NullableDoubleNestedPropertyChanging()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanging(x => x.NullableInnerPropertyChanged, x => x.NullableInnerPropertyChanged, x => x.Value)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([0]);
+
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged.Value = 1;
+
+        liveList.AssertEqual([0, 0]);
+
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged.Value = 2;
+
+        liveList.AssertEqual([0, 0, 1]);
+    }
+
+    [Fact]
+    public void NullableDoubleNestedPropertyChangingWithNullableEndProperty()
+    {
+        ChangesProperty propertyChanger = new();
+
+        using var liveList = propertyChanger
+            .ObservePropertyChanging(x => x.NullableInnerPropertyChanged, x => x.NullableInnerPropertyChanged, x => x.NullableInnerPropertyChanged)
+            .ToLiveList();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([]);
+
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged = new();
+
+        liveList.AssertEqual([null]);
+
+        var nipc1 = new ChangesProperty();
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged.NullableInnerPropertyChanged = nipc1;
+
+        liveList.AssertEqual([null, null]);
+
+        var nipc2 = new ChangesProperty();
+        propertyChanger.NullableInnerPropertyChanged.NullableInnerPropertyChanged.NullableInnerPropertyChanged = nipc2;
+
+        liveList.AssertEqual([null, null, nipc1]);
+    }
+
     class ChangesProperty : INotifyPropertyChanged, INotifyPropertyChanging
     {
         private int _value;
         private ChangesProperty _innerPropertyChanged = default!;
+        private ChangesProperty? _nullableInnerPropertyChanged;
 
         public event PropertyChangedEventHandler? PropertyChanged;
         public event PropertyChangingEventHandler? PropertyChanging;
@@ -155,6 +404,12 @@ public class ObservePropertyTest
         {
             get => _innerPropertyChanged;
             set => SetField(ref _innerPropertyChanged, value);
+        }
+
+        public ChangesProperty? NullableInnerPropertyChanged
+        {
+            get => _nullableInnerPropertyChanged;
+            set => SetField(ref _nullableInnerPropertyChanged, value);
         }
 
         private void OnPropertyChanged([CallerMemberName] string? propertyName = null)


### PR DESCRIPTION
The code changes involve updating the property selectors in the Observable class to handle nullable types. This includes modifying the function signatures and return types of ObservePropertyChanged and ObservePropertyChanging methods. Additionally, new test cases have been added to validate these changes, ensuring that properties can be observed correctly even when they are null or their values change.