### PR TITLE
Property Binding

### DIFF
--- a/src/R3/Factories/Bind.cs
+++ b/src/R3/Factories/Bind.cs
@@ -1,0 +1,85 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace R3;
+
+public static partial class Observable
+{
+    public static IDisposable TwoWayBind<TIn, TProperty, TOut>(
+        this TIn valueIn, Func<TIn, TProperty> valueInPropertyGet, Action<TIn, TProperty> valueInPropertySet,
+        TOut valueOut, Func<TOut, TProperty> valueOutPropertyGet, Action<TOut, TProperty> valueOutPropertySet,
+        CancellationToken cancellationToken = default,
+        [CallerArgumentExpression(nameof(valueInPropertyGet))] string? exprIn = null,
+        [CallerArgumentExpression(nameof(valueOutPropertyGet))] string? exprOut = null)
+        where TIn : INotifyPropertyChanged
+        where TOut : INotifyPropertyChanged
+    {
+        return Disposable.Combine(
+            valueIn
+                .ObservePropertyChanged(valueInPropertyGet, true, cancellationToken, exprIn)
+                .Subscribe(
+                    (valueOut, valueOutPropertySet),
+                    (x, state) =>
+                    {
+                        state.valueOutPropertySet(state.valueOut, x);
+                    }),
+            valueOut
+                .ObservePropertyChanged(valueOutPropertyGet, false, cancellationToken, exprOut)
+                .Subscribe(
+                    (valueIn, valueInPropertySet),
+                    (x, state) =>
+                    {
+                        state.valueInPropertySet(state.valueIn, x);
+                    }));
+    }
+
+    /** Could potentially come up ways to mix and match INPC with EVC
+    public static IDisposable TwoWayBind<TIn, TProperty, TOut>(
+        this TIn valueIn, Func<TIn, TProperty> valueInPropertyGet, Func<TProperty, TIn> valueInPropertySet,
+        TOut valueOut, Func<TOut, TProperty> valueOutPropertyGet, Func<TProperty, TOut> valueOutPropertySet,
+        CancellationToken cancellationToken = default,
+        [CallerArgumentExpression(nameof(valueInPropertyGet))] string? exprIn = null)
+        where TIn : INotifyPropertyChanged
+        where TOut : class
+    {
+        return Disposable.Combine(
+            valueIn
+                .ObservePropertyChanged(valueInPropertyGet, true, cancellationToken, exprIn)
+                .Subscribe(valueOutPropertySet, (x, state) => state(x)),
+            EveryValueChanged(valueOut, valueOutPropertyGet, cancellationToken)
+                .Skip(1)
+                .Subscribe(valueInPropertySet, (x, state) => state(x)));
+    }
+
+    public static IDisposable TwoWayBind<TIn, TProperty, TOut>(
+        this TIn valueIn, Func<TIn, TProperty> valueInPropertyGet, Func<TProperty, TIn> valueInPropertySet,
+        TOut valueOut, Func<TOut, TProperty> valueOutPropertyGet, Func<TProperty, TOut> valueOutPropertySet,
+        CancellationToken cancellationToken = default,
+        [CallerArgumentExpression(nameof(valueOutPropertyGet))] string? exprOut = null)
+        where TIn : class
+        where TOut : INotifyPropertyChanged
+    {
+        return Disposable.Combine(
+            EveryValueChanged(valueIn, valueInPropertyGet, cancellationToken)
+                .Subscribe(valueOutPropertySet, (x, state) => state(x)),
+            valueOut
+                .ObservePropertyChanged(valueOutPropertyGet, false, cancellationToken, exprOut)
+                .Subscribe(valueInPropertySet, (x, state) => state(x)));
+    }
+
+    public static IDisposable TwoWayBind<TIn, TProperty, TOut>(
+        this TIn valueIn, Func<TIn, TProperty> valueInPropertyGet, Func<TProperty, TIn> valueInPropertySet,
+        TOut valueOut, Func<TOut, TProperty> valueOutPropertyGet, Func<TProperty, TOut> valueOutPropertySet,
+        CancellationToken cancellationToken = default)
+        where TIn : class
+        where TOut : class
+    {
+        return Disposable.Combine(
+            EveryValueChanged(valueIn, valueInPropertyGet, cancellationToken)
+                .Subscribe(valueOutPropertySet, (x, state) => state(x)),
+            EveryValueChanged(valueOut, valueOutPropertyGet, cancellationToken)
+                .Skip(1)
+                .Subscribe(valueInPropertySet, (x, state) => state(x)));
+    }
+    **/
+}

--- a/tests/R3.Tests/BindTest.cs
+++ b/tests/R3.Tests/BindTest.cs
@@ -1,0 +1,88 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using R3.Tests.FactoryTests;
+
+namespace R3.Tests;
+
+public class BindTest
+{
+    [Fact]
+    public void NotifyPropertyChangedTest()
+    {
+        ChangesProperty propertyChanger1 = new();
+        propertyChanger1.Value = 1;
+
+        ChangesProperty propertyChanger2 = new();
+        propertyChanger2.Value = 2;
+
+        propertyChanger1
+            .TwoWayBind(
+                x => x.Value, (value, x) => value.Value = x,
+                propertyChanger2, x => x.Value, (value, x) => value.Value = x);
+
+        Assert.Equal(propertyChanger1.Value, 1);
+        Assert.Equal(propertyChanger2.Value, 1);
+
+        propertyChanger1.Value = 2;
+
+        Assert.Equal(propertyChanger1.Value, 2);
+        Assert.Equal(propertyChanger2.Value, 2);
+
+        propertyChanger2.Value = 3;
+
+        Assert.Equal(propertyChanger1.Value, 3);
+        Assert.Equal(propertyChanger2.Value, 3);
+    }
+
+    class ChangesProperty : INotifyPropertyChanged, INotifyPropertyChanging
+    {
+        private int _value;
+        private ChangesProperty _innerPropertyChanged = default!;
+        private ChangesProperty? _nullableInnerPropertyChanged;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        public event PropertyChangingEventHandler? PropertyChanging;
+
+        public int Value
+        {
+            get => _value;
+            set => SetField(ref _value, value);
+        }
+
+        public ChangesProperty InnerPropertyChanged
+        {
+            get => _innerPropertyChanged;
+            set => SetField(ref _innerPropertyChanged, value);
+        }
+
+        public ChangesProperty? NullableInnerPropertyChanged
+        {
+            get => _nullableInnerPropertyChanged;
+            set => SetField(ref _nullableInnerPropertyChanged, value);
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private void OnPropertyChanging([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanging?.Invoke(this, new PropertyChangingEventArgs(propertyName));
+        }
+
+        private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+
+            OnPropertyChanging(propertyName);
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+    }
+}


### PR DESCRIPTION
*This is just a quick proof of concept for consideration and to get feedback on a feature like this.*

In ReactiveUI and ReactiveMarbles there is a very helpful and cross-platform concept of data binding. Example and details [here](https://www.reactiveui.net/docs/handbook/data-binding/) and [here](https://github.com/reactivemarbles/PropertyChanged#binding). What is great about this binding is that it can be applied consistently across platforms. For MVVM-supported platforms, this makes the transition across these various platforms very easy as you do not need to know the intricacies of each platform's binding language.

An implementation of this for R3 could be powerful and offer a nice way to bind components together. It feels like it would be a decent candidate for an opt-in/additional library like `R3.Binding` or similar. A binding like this would best be driven by source generators and could internally be backed by the `ObservePropertyChanged` and `EveryValueChanged` methods to allow for universal coverage of binding of objects that implement `INotifyPropertyChanged` and for plain .NET objects.

Any thoughts on having support for a feature like this added as an extension library?