### PR TITLE
Add ScanSelect(Func<TSource, TSource, TResult>) (TState, Func<TSource, TSource, TState, TResult>)

### DIFF
--- a/src/R3/Operators/Scan.cs
+++ b/src/R3/Operators/Scan.cs
@@ -24,13 +24,13 @@ internal sealed class Scan<TSource>(Observable<TSource> source, Func<TSource, TS
     {
         readonly Observer<TSource> observer;
         readonly Func<TSource, TSource, TSource> accumulator;
-        TSource state;
+        TSource accumulation;
         bool hasValue;
 
         public _Scan(Observer<TSource> observer, Func<TSource, TSource, TSource> accumulator)
         {
             this.observer = observer;
-            this.state = default!;
+            this.accumulation = default!;
             this.accumulator = accumulator;
         }
 
@@ -39,13 +39,13 @@ internal sealed class Scan<TSource>(Observable<TSource> source, Func<TSource, TS
             if (!hasValue)
             {
                 hasValue = true;
-                state = value;
-                observer.OnNext(state);
+                accumulation = value;
+                observer.OnNext(accumulation);
                 return;
             }
 
-            state = accumulator(state, value);
-            observer.OnNext(state);
+            accumulation = accumulator(accumulation, value);
+            observer.OnNext(accumulation);
         }
 
         protected override void OnErrorResumeCore(Exception error)
@@ -71,19 +71,19 @@ internal sealed class Scan<TSource, TAccumulate>(Observable<TSource> source, TAc
     {
         readonly Observer<TAccumulate> observer;
         readonly Func<TAccumulate, TSource, TAccumulate> accumulator;
-        TAccumulate state;
+        TAccumulate accumulation;
 
         public _Scan(Observer<TAccumulate> observer, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> accumulator)
         {
             this.observer = observer;
-            this.state = seed;
+            this.accumulation = seed;
             this.accumulator = accumulator;
         }
 
         protected override void OnNextCore(TSource value)
         {
-            state = accumulator(state, value);
-            observer.OnNext(state);
+            accumulation = accumulator(accumulation, value);
+            observer.OnNext(accumulation);
         }
 
         protected override void OnErrorResumeCore(Exception error)

--- a/src/R3/Operators/ScanSelect.cs
+++ b/src/R3/Operators/ScanSelect.cs
@@ -1,0 +1,146 @@
+﻿namespace R3;
+
+public static partial class ObservableExtensions
+{
+    public static Observable<TResult> ScanSelect<TSource, TResult>(this Observable<TSource> source, Func<TSource, TSource, TResult> selector)
+    {
+        if (source is Where<TSource> where)
+        {
+            // Optimize for WhereScanSelect
+            return new WhereScanSelect<TSource, TResult>(where.source, selector, where.predicate);
+        }
+
+        return new ScanSelect<TSource, TResult>(source, selector);
+    }
+
+    // TState
+
+    public static Observable<TResult> ScanSelect<TSource, TResult, TState>(this Observable<TSource> source, TState state, Func<TSource, TSource, TState, TResult> selector)
+    {
+        return new ScanSelect<TSource, TResult, TState>(source, selector, state);
+    }
+}
+
+internal sealed class ScanSelect<T, TResult>(Observable<T> source, Func<T, T, TResult> selector) : Observable<TResult>
+{
+    protected override IDisposable SubscribeCore(Observer<TResult> observer)
+    {
+        return source.Subscribe(new _ScanSelect(observer, selector));
+    }
+
+    sealed class _ScanSelect : Observer<T>
+    {
+        readonly Observer<TResult> observer;
+        readonly Func<T, T, TResult> selector;
+        T accumulation;
+
+        public _ScanSelect(Observer<TResult> observer, Func<T, T, TResult> selector)
+        {
+            this.observer = observer;
+            this.accumulation = default!;
+            this.selector = selector;
+        }
+
+        protected override void OnNextCore(T value)
+        {
+            var result = selector(accumulation, value);
+            accumulation = value;
+            observer.OnNext(result);
+        }
+
+        protected override void OnErrorResumeCore(Exception error)
+        {
+            observer.OnErrorResume(error);
+        }
+
+        protected override void OnCompletedCore(Result result)
+        {
+            observer.OnCompleted(result);
+        }
+    }
+}
+
+internal sealed class ScanSelect<T, TResult, TState>(Observable<T> source, Func<T, T, TState, TResult> selector, TState state) : Observable<TResult>
+{
+    protected override IDisposable SubscribeCore(Observer<TResult> observer)
+    {
+        return source.Subscribe(new _ScanSelect(observer, selector, state));
+    }
+
+    sealed class _ScanSelect : Observer<T>
+    {
+        readonly Observer<TResult> observer;
+        readonly Func<T, T, TState, TResult> selector;
+        T accumulation;
+        TState state;
+
+        public _ScanSelect(Observer<TResult> observer, Func<T, T, TState, TResult> selector, TState state)
+        {
+            this.observer = observer;
+            this.accumulation = default!;
+            this.selector = selector;
+            this.state = state;
+        }
+
+        protected override void OnNextCore(T value)
+        {
+            var result = selector(accumulation, value, state);
+            accumulation = value;
+            observer.OnNext(result);
+        }
+
+        protected override void OnErrorResumeCore(Exception error)
+        {
+            observer.OnErrorResume(error);
+        }
+
+        protected override void OnCompletedCore(Result result)
+        {
+            observer.OnCompleted(result);
+        }
+    }
+}
+
+internal sealed class WhereScanSelect<T, TResult>(Observable<T> source, Func<T, T, TResult> selector, Func<T, bool> predicate) : Observable<TResult>
+{
+    protected override IDisposable SubscribeCore(Observer<TResult> observer)
+    {
+        return source.Subscribe(new _WhereScanSelect(observer, selector, predicate));
+    }
+
+    sealed class _WhereScanSelect : Observer<T>
+    {
+        readonly Observer<TResult> observer;
+        readonly Func<T, T, TResult> selector;
+        readonly Func<T, bool> predicate;
+        T accumulation;
+
+        public _WhereScanSelect(Observer<TResult> observer, Func<T, T, TResult> selector, Func<T, bool> predicate)
+        {
+            this.observer = observer;
+            this.accumulation = default!;
+            this.selector = selector;
+            this.predicate = predicate;
+        }
+
+        protected override void OnNextCore(T value)
+        {
+            if (predicate(value))
+            {
+                var result = selector(accumulation, value);
+                accumulation = value;
+                observer.OnNext(result);
+            }
+        }
+
+        protected override void OnErrorResumeCore(Exception error)
+        {
+            observer.OnErrorResume(error);
+        }
+
+        protected override void OnCompletedCore(Result result)
+        {
+            observer.OnCompleted(result);
+        }
+    }
+}


### PR DESCRIPTION
This was implemented to address a use case I was faced with.

I could not think of a way to implement similar functionality with an existing combination of operators. 

Therefore, I am proposing this because I think it would be useful if it were available.

Of course, I leave it up to you to decide if you want to incorporate it into this repository.

> notes
Some existing variables have been renamed for consistency in the source code.