### PR TITLE
Adds support for TimerFrameProvider to Blazor registration

### DIFF
--- a/sandbox/BlazorApp1/Components/Pages/Counter.razor
+++ b/sandbox/BlazorApp1/Components/Pages/Counter.razor
@@ -8,13 +8,4 @@
 
 <p role="status">Current count: @currentCount</p>
 
-@* <button class="btn btn-primary" @onclick="IncrementCount">Click me</button> *@
-
-@code {
-    // private int currentCount = 0;
-
-    // private void IncrementCount()
-    // {
-    //     currentCount++;
-    // }
-}
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>

--- a/sandbox/BlazorApp1/Components/Pages/Counter.razor.cs
+++ b/sandbox/BlazorApp1/Components/Pages/Counter.razor.cs
@@ -16,10 +16,19 @@ public partial class Counter : IDisposable
                 currentCount++;
                 StateHasChanged();
             });
+
+        Observable
+            .EveryValueChanged(this, x => x.currentCount)
+            .Subscribe(cc => { Console.WriteLine($"Current Count: {cc}"); });
     }
 
     public void Dispose()
     {
         subscription?.Dispose();
+    }
+
+    private void IncrementCount()
+    {
+        currentCount++;
     }
 }


### PR DESCRIPTION
In `Blazor` there wasn't support for a FrameProvider. This adds support using the `TimerFrameProvider`. This appears to work out okay for the Blazor project and makes it so that features like `EveryValueChanged` are available. I am not sure if there are any downsides to adding this registration or if it could cause an overhead processing issue.

Ambient CPU usage doesn't seem to be greatly impacted.
<img width="317" alt="image" src="https://github.com/Cysharp/R3/assets/120685/7950eae1-fee1-4457-8fce-59ca58501f84">
