### PR TITLE
FIX: UIBehaviour is a part of uGUI

### DIFF
--- a/src/R3.Unity/Assets/R3.Unity/Runtime/Triggers/ObservableTriggerExtensions.Component.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/Triggers/ObservableTriggerExtensions.Component.cs
@@ -329,7 +329,7 @@ namespace R3.Triggers
         // uGUI
 
         #region ObservableEventTrigger classes
-
+#if R3_UGUI_SUPPORT
         public static Observable<BaseEventData> OnDeselectAsObservable(this UIBehaviour component)
         {
             if (component == null || component.gameObject == null) return Observable.Empty<BaseEventData>();
@@ -431,7 +431,7 @@ namespace R3.Triggers
             if (component == null || component.gameObject == null) return Observable.Empty<PointerEventData>();
             return GetOrAddComponent<ObservableScrollTrigger>(component.gameObject).OnScrollAsObservable();
         }
-
+#endif
         #endregion
 
         #region ObservableParticleTrigger


### PR DESCRIPTION
Fixed the compilation error that occurs when `com.unity.ugui` is not installed.