### PR TITLE
AddTo support for Godot Node

### DIFF
--- a/src/R3.Godot/addons/R3.Godot/GodotNodeExtensions.cs
+++ b/src/R3.Godot/addons/R3.Godot/GodotNodeExtensions.cs
@@ -3,7 +3,7 @@ using Godot;
 
 namespace R3;
 
-public static class NodeExtensions
+public static class GodotNodeExtensions
 {
     /// <summary>
     /// Dispose self on target node has bee tree exited.

--- a/src/R3.Godot/addons/R3.Godot/GodotNodeExtensions.cs
+++ b/src/R3.Godot/addons/R3.Godot/GodotNodeExtensions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Godot;
+
+namespace R3;
+
+public static class NodeExtensions
+{
+    /// <summary>
+    /// Dispose self on target node has bee tree exited.
+    /// </summary>
+    /// <param name="disposable"></param>
+    /// <param name="node"></param>
+    /// <typeparam name="T"></typeparam>
+    /// <returns>Self disposable</returns>
+    public static T AddTo<T>(this T disposable, Node node) where T : IDisposable
+    {
+        // Note: Dispose when tree exited, so if node is not inside tree, dispose immediately.
+        if (!node.IsInsideTree()) 
+        {
+            if (!node.IsNodeReady()) // Before enter tree
+            {
+                GD.PrintErr("AddTo does not support to use before enter tree.");
+            }
+
+            disposable.Dispose();
+            return disposable;
+        }
+        
+        node.TreeExited += () => disposable.Dispose();
+        return disposable;
+    }
+}


### PR DESCRIPTION
Add AddTo extension method for Godot.Node class.

```cs
public partial class Foo :  Node
{
    private readonly Subject<Unit> _s = new();

    public override void _Ready()
    {
        _s.AddTo(this);
    }
}
```

Disposable will be disposed when node has been exited tree.  
If this method is called before enter tree, there is no guarantee that it will be dispiosed, so a warning log is displayed if it is called on a constructor or the like.