### PR TITLE
Fixed Trampoline could not be reused

### DIFF
--- a/src/R3/Operators/Trampoline.cs
+++ b/src/R3/Operators/Trampoline.cs
@@ -67,6 +67,7 @@ internal sealed class Trampoline<T>(Observable<T> source) : Observable<T>
 
                 if (!queue.TryDequeue(out value))
                 {
+                    running = false;
                     return;
                 }
             }

--- a/tests/R3.Tests/OperatorTests/TrampolineTest.cs
+++ b/tests/R3.Tests/OperatorTests/TrampolineTest.cs
@@ -77,4 +77,42 @@ B : OnPlayerAddTeam
 C : OnPlayerAddTeam
 """);
     }
+
+
+    [Fact]
+    public void TrampolineIsReusable()
+    {
+        var sender = new Subject<string>();
+        var receiver = sender.Trampoline().Share();
+
+        var log = new List<string>();
+
+        // A
+        receiver.Subscribe(x =>
+        {
+            log.Add(x);
+            if (x == "OnPlayerJoined") sender.OnNext("OnPlayerAddTeam");
+        });
+
+        sender.OnNext("OnPlayerJoined");
+
+        var msg = string.Join(Environment.NewLine, log);
+
+        msg.Should().Be("""
+                        OnPlayerJoined
+                        OnPlayerAddTeam
+                        """);
+
+        // reset logs
+        log.Clear();
+
+        // send again
+        sender.OnNext("OnPlayerJoined");
+
+        msg = string.Join(Environment.NewLine, log);
+        msg.Should().Be("""
+                        OnPlayerJoined
+                        OnPlayerAddTeam
+                        """);
+    }
 }


### PR DESCRIPTION
Once the `Trampoline` operator worked once, it would not work a second time.