### PR TITLE
Incorrectly Combine instead of Dispose

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,7 +874,7 @@ public class CommandViewModel : IDisposable
 
     public void Dispose()
     {
-        Disposable.Combine(OnCheck, ShowMessageBox);
+        Disposable.Dispose(OnCheck, ShowMessageBox);
     }
 }
 ```


### PR DESCRIPTION
Dispose method incorrectly calls Disposable.Combine instead of Disposable.Dispose