### PR TITLE
[Godot] Ensure that ObservableTrackerDebuggerPlugin sessions Dictionary is no…

### DIFF
--- a/src/R3.Godot/addons/R3.Godot/ObservableTrackerDebuggerPlugin.cs
+++ b/src/R3.Godot/addons/R3.Godot/ObservableTrackerDebuggerPlugin.cs
@@ -96,7 +96,7 @@ public partial class ObservableTrackerDebuggerPlugin : EditorDebuggerPlugin
                     foreach (GDArray item in data[1].AsGodotArray())
                     {
                         var state = new TrackingState()
-                        { 
+                        {
                             TrackingId = item[0].AsInt32(),
                             FormattedType = item[1].AsString(),
                             AddTime = new DateTime(item[2].AsInt64()),
@@ -113,17 +113,19 @@ public partial class ObservableTrackerDebuggerPlugin : EditorDebuggerPlugin
 
     public void RegisterReceivedActiveTasks(int sessionId, Action<IEnumerable<TrackingState>> action)
     {
-        sessions[sessionId].ReceivedActiveTasks += action;
+        if (sessions.Count > 0)
+            sessions[sessionId].ReceivedActiveTasks += action;
     }
-    
+
     public void UnregisterReceivedActiveTasks(int sessionId, Action<IEnumerable<TrackingState>> action)
     {
-        sessions[sessionId].ReceivedActiveTasks -= action;
+        if (sessions.Count > 0)
+            sessions[sessionId].ReceivedActiveTasks -= action;
     }
 
     public void UpdateTrackingStates(int sessionId, bool forceUpdate = false)
     {
-        if (sessions[sessionId].debuggerSession.IsActive())
+        if (sessions.Count > 0 && sessions[sessionId].debuggerSession.IsActive())
         {
             sessions[sessionId].debuggerSession.SendMessage(MessageHeader + ":" + Message_RequestActiveTasks, new () { forceUpdate });
         }
@@ -131,7 +133,7 @@ public partial class ObservableTrackerDebuggerPlugin : EditorDebuggerPlugin
 
     public void SetEnableStates(int sessionId, bool enableTracking, bool enableStackTrace)
     {
-        if (sessions[sessionId].debuggerSession.IsActive())
+        if (sessions.Count > 0 && sessions[sessionId].debuggerSession.IsActive())
         {
             sessions[sessionId].debuggerSession.SendMessage(MessageHeader + ":" + Message_SetEnableStates, new () { enableTracking, enableStackTrace});
         }
@@ -139,7 +141,7 @@ public partial class ObservableTrackerDebuggerPlugin : EditorDebuggerPlugin
 
     public void InvokeGCCollect(int sessionId)
     {
-        if (sessions[sessionId].debuggerSession.IsActive())
+        if (sessions.Count > 0 && sessions[sessionId].debuggerSession.IsActive())
         {
             sessions[sessionId].debuggerSession.SendMessage(MessageHeader + ":" + Message_InvokeGCCollect);
         }


### PR DESCRIPTION
With Godot 4.3beta2 it seems that #125 is finally fixed R3 is finally usable with Godot but there is another problem. I'm not sure if it's introduced in this version or previous.
If you enable R3 as plugin and then rebuild C# project without previous running debugging session plugin will try to call `ObservableTrackerDebuggerPlugin.UpdateTrackingStates` while `Dictionary<int, TrackerSession> sessions` is empty which will cause exception.
```

/root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/NativeInterop/ExceptionUtils.cs:113 - System.Collections.Generic.KeyNotFoundException: The given key '0' was not present in the dictionary.
     at System.Collections.Generic.Dictionary`2.get_Item(TKey key)
     at R3.ObservableTrackerDebuggerPlugin.UpdateTrackingStates(Int32 sessionId, Boolean forceUpdate) in D:\Projects\Other\UnloadingIssue\addons\R3.Godot\ObservableTrackerDebuggerPlugin.cs:line 126
     at R3.ObservableTrackerTab._Process(Double delta) in D:\Projects\Other\UnloadingIssue\addons\R3.Godot\ObservableTrackerTab.cs:line 129
     at Godot.Node.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/Node.cs:line 2395
     at Godot.CanvasItem.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/CanvasItem.cs:line 1504
     at Godot.Control.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/Control.cs:line 2912
     at Godot.Container.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/Container.cs:line 137
     at Godot.BoxContainer.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/BoxContainer.cs:line 136
     at Godot.VBoxContainer.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Generated/GodotObjects/VBoxContainer.cs:line 42
     at R3.ObservableTrackerTab.InvokeGodotClassMethod(godot_string_name& method, NativeVariantPtrArgs args, godot_variant& ret) in D:\Projects\Other\UnloadingIssue\.godot\mono\temp\obj\Debug\Godot.SourceGenerators\Godot.SourceGenerators.ScriptMethodsGenerator\R3.ObservableTrackerTab_ScriptMethods.generated.cs:line 80
     at Godot.Bridge.CSharpInstanceBridge.Call(IntPtr godotObjectGCHandle, godot_string_name* method, godot_variant** args, Int32 argCount, godot_variant_call_error* refCallError, godot_variant* ret) in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/CSharpInstanceBridge.cs:line 24
```
     
