### PR TITLE
ToBindableReadOnlyReactiveProperty -> ToReadOnlyBindableReactiveProperty

### DIFF
--- a/sandbox/WpfApp1/MainWindow.xaml.cs
+++ b/sandbox/WpfApp1/MainWindow.xaml.cs
@@ -63,7 +63,7 @@ public class BasicUsagesViewModel : IDisposable
     public BasicUsagesViewModel()
     {
         Input = new BindableReactiveProperty<string>("");
-        Output = Input.Select(x => x.ToUpper()).ToBindableReadOnlyReactiveProperty("");
+        Output = Input.Select(x => x.ToUpper()).ToReadOnlyBindableReactiveProperty("");
     }
 
     public void Dispose()

--- a/src/R3/ReactivePropertyExtensions.cs
+++ b/src/R3/ReactivePropertyExtensions.cs
@@ -30,12 +30,12 @@ public static class ReactivePropertyExtensions
         return new BindableReactiveProperty<T>(source, initialValue, equalityComparer);
     }
 
-    public static IBindableReactiveProperty ToBindableReadOnlyReactiveProperty<T>(this Observable<T> source, T initialValue = default!)
+    public static IBindableReactiveProperty ToReadOnlyBindableReactiveProperty<T>(this Observable<T> source, T initialValue = default!)
     {
         return new BindableReactiveProperty<T>(source, initialValue, EqualityComparer<T>.Default);
     }
 
-    public static IBindableReactiveProperty ToBindableReadOnlyReactiveProperty<T>(this Observable<T> source, IEqualityComparer<T>? equalityComparer, T initialValue = default!)
+    public static IBindableReactiveProperty ToReadOnlyBindableReactiveProperty<T>(this Observable<T> source, IEqualityComparer<T>? equalityComparer, T initialValue = default!)
     {
         return new BindableReactiveProperty<T>(source, initialValue, equalityComparer);
     }


### PR DESCRIPTION
# Summary

Rename `ToBindableReadOnlyReactiveProperty`
 to `ToReadOnlyBindableReactiveProperty `.

# Motivation

Match the existing type name `IReadOnlyBindableReactiveProperty `.

https://github.com/Cysharp/R3/commit/f893787e692965c26da04b8b6f637d22edbedea4