### PR TITLE
Add `WhereNotNull` operator

### DIFF
--- a/src/R3/Operators/WhereNotNull.cs
+++ b/src/R3/Operators/WhereNotNull.cs
@@ -1,0 +1,13 @@
+﻿namespace R3;
+
+public static partial class ObservableExtensions
+{
+    public static Observable<TResult> WhereNotNull<TResult>(this Observable<TResult?> source) where TResult : class
+    {
+        return new WhereSelect<TResult?, TResult>(
+            source: source,
+            selector: static item => item!,
+            predicate: item => item is not null
+        );
+    }
+}

--- a/tests/R3.Tests/OperatorTests/WhereNotNullTest.cs
+++ b/tests/R3.Tests/OperatorTests/WhereNotNullTest.cs
@@ -1,0 +1,24 @@
+﻿namespace R3.Tests.OperatorTests;
+
+public class WhereNotNullTest(ITestOutputHelper output)
+{
+    [Fact]
+    public void WhereNotNull()
+    {
+        var p = new Subject<string?>();
+
+        using var list = p.WhereNotNull().ToLiveList();
+
+        p.OnNext(null);
+        list.AssertEqual([]);
+
+        p.OnNext("foo");
+        list.AssertEqual(["foo"]);
+
+        p.OnNext(null);
+        list.AssertEqual(["foo"]);
+
+        p.OnNext("bar");
+        list.AssertEqual(["foo", "bar"]);
+    }
+}


### PR DESCRIPTION
Using optimized `WhereSelect`, the `WhereNotNull` operator is very common and many libraries and applications had to DIY implement this for `System.IObservable<T>`.