### PR TITLE
change EnableNotifyError field to property

### DIFF
--- a/src/R3/BindableReactiveProperty.cs
+++ b/src/R3/BindableReactiveProperty.cs
@@ -12,6 +12,7 @@ namespace R3;
 public interface IReadOnlyBindableReactiveProperty : INotifyPropertyChanged, INotifyDataErrorInfo, IDisposable
 {
     object? Value { get; }
+    bool EnableNotifyError { get; }
 }
 
 public interface IReadOnlyBindableReactiveProperty<T> : IReadOnlyBindableReactiveProperty
@@ -110,7 +111,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
 
     protected override void OnValueChanged(T value)
     {
-        if (enableNotifyError)
+        if (EnableNotifyError)
         {
             // comes new value, require to clear error.
             var previouslyHasErrors = (errors != null && errors.Count != 0);
@@ -161,7 +162,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
 
     PropertyValidationContext? validationContext;
     Func<T, Exception?>? validator;
-    bool enableNotifyError = false; // default is false
+    public bool EnableNotifyError { get; private set; } = false; // default is false
     List<ValidationResult>? errors;
 
     public event EventHandler<DataErrorsChangedEventArgs>? ErrorsChanged;
@@ -183,7 +184,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
 
     protected override void OnReceiveError(Exception exception)
     {
-        if (!enableNotifyError) return;
+        if (!EnableNotifyError) return;
 
         var aggregateException = exception as AggregateException;
 
@@ -217,7 +218,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
 
     public BindableReactiveProperty<T> EnableValidation()
     {
-        enableNotifyError = true;
+        EnableNotifyError = true;
         return this;
     }
 
@@ -225,7 +226,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
     {
         this.validator = validator;
 
-        enableNotifyError = true;
+        EnableNotifyError = true;
         return this;
     }
 
@@ -234,7 +235,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
         var propertyInfo = typeof(TClass).GetProperty(propertyName!, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
         SetValidationContext(propertyInfo!);
 
-        enableNotifyError = true;
+        EnableNotifyError = true;
         return this;
     }
 
@@ -244,7 +245,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
         var propertyInfo = (PropertyInfo)memberExpression.Member;
         SetValidationContext(propertyInfo);
 
-        enableNotifyError = true;
+        EnableNotifyError = true;
         return this;
     }
 
@@ -299,7 +300,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
         var propertyInfo = (PropertyInfo)memberExpression.Member;
         SetValidationContext(propertyInfo);
 
-        enableNotifyError = true;
+        EnableNotifyError = true;
         return this;
     }
 
@@ -322,7 +323,7 @@ public class BindableReactiveProperty<T> : ReactiveProperty<T>, IBindableReactiv
         var propertyInfo = (PropertyInfo)memberExpression.Member;
         SetValidationContext(propertyInfo);
 
-        enableNotifyError = true;
+        EnableNotifyError = true;
         return this;
     }
 

--- a/src/R3/ReactivePropertyExtensions.cs
+++ b/src/R3/ReactivePropertyExtensions.cs
@@ -83,6 +83,7 @@ internal sealed class ConnectedReactiveProperty<T> : ReactiveProperty<T>
 internal sealed class ReadOnlyBindableReactiveProperty<T>(BindableReactiveProperty<T> property) : IReadOnlyBindableReactiveProperty<T>
 {
     public T Value => ((IReadOnlyBindableReactiveProperty<T>)property).Value;
+    public bool EnableNotifyError => ((IReadOnlyBindableReactiveProperty<T>)property).EnableNotifyError;
 
     public bool HasErrors => ((INotifyDataErrorInfo)property).HasErrors;
 


### PR DESCRIPTION
I have created a library called [R3Utility](https://github.com/zerodev1200/R3Utility/). 
In this library, I have defined the following method:

```csharp
public static Observable<bool> CreateCanExecuteSource(bool forceInitialNotification = true, params IBindableReactiveProperty[] properties)
{
    if (properties == null || properties.Length == 0)
    {
        throw new ArgumentNullException(nameof(properties));
    }
    // Create observables for HasErrors of each property
    var errorObservables = properties
                            .Select(prop =>
                            {
                                if (forceInitialNotification)
                                {
                                    prop.OnNext(prop.Value); // Force initial notification
                                }
                                return Observable.EveryValueChanged(prop, x => x.HasErrors);
                            });
    return errorObservables.CombineLatestValuesAreAllFalse();
}
```

By changing EnableNotifyError to a property, I can now perform the following validation:
```csharp
if (!prop.EnableNotifyError)
{
    throw new ArgumentException($"Property must have EnableValidation() called.");
}
```

I placed `bool EnableNotifyError { get; }` in the non-generic interface rather than the generic one to ensure it can be accessed regardless of the type in the above method.

Please review this implementation.