### PR TITLE
Adds support for threading lock in .NET 9 and C# 13

### DIFF
--- a/src/R3.Avalonia/AvaloniaDispatcherFrameProvider.cs
+++ b/src/R3.Avalonia/AvaloniaDispatcherFrameProvider.cs
@@ -13,7 +13,11 @@ public sealed class AvaloniaDispatcherFrameProvider : FrameProvider, IDisposable
     bool disposed;
     long frameCount;
     FreeListCore<IFrameRunnerWorkItem> list;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
     readonly DispatcherTimer timer;
     EventHandler timerTick;
 

--- a/src/R3.Avalonia/AvaloniaRenderingFrameProvider.cs
+++ b/src/R3.Avalonia/AvaloniaRenderingFrameProvider.cs
@@ -10,7 +10,11 @@ public class AvaloniaRenderingFrameProvider : FrameProvider, IDisposable
     bool disposed;
     long frameCount;
     FreeListCore<IFrameRunnerWorkItem> list;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
 
     Action<TimeSpan> messageLoop;
 

--- a/src/R3.Avalonia/ObserveOnExtensions.cs
+++ b/src/R3.Avalonia/ObserveOnExtensions.cs
@@ -40,7 +40,12 @@ internal sealed class ObserveOnDispatcher<T>(Observable<T> source, Dispatcher di
         readonly Observer<T> observer;
         readonly Dispatcher dispatcher;
         readonly DispatcherPriority? dispatcherPriority;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
+
         SwapListCore<Notification<T>> list;
         bool running;
 

--- a/src/R3.Avalonia/R3.Avalonia.csproj
+++ b/src/R3.Avalonia/R3.Avalonia.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1591;1573</NoWarn>
 

--- a/src/R3.Blazor/R3.Blazor.csproj
+++ b/src/R3.Blazor/R3.Blazor.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1591;1573</NoWarn>
         <RootNamespace>R3</RootNamespace>

--- a/src/R3.BlazorWebAssembly/R3.BlazorWebAssembly.csproj
+++ b/src/R3.BlazorWebAssembly/R3.BlazorWebAssembly.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
         <OutputType>Library</OutputType>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1591;1573</NoWarn>
         <RootNamespace>R3</RootNamespace>

--- a/src/R3.Godot/addons/R3.Godot/GodotFrameProvider.cs
+++ b/src/R3.Godot/addons/R3.Godot/GodotFrameProvider.cs
@@ -19,7 +19,11 @@ public class GodotFrameProvider : FrameProvider
     public static readonly GodotFrameProvider PhysicsProcess = new GodotFrameProvider(PlayerLoopTiming.PhysicsProcess);
 
     FreeListCore<IFrameRunnerWorkItem> list;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
 
     PlayerLoopTiming PlayerLoopTiming { get; }
 

--- a/src/R3.Godot/addons/R3.Godot/GodotTimeProvider.cs
+++ b/src/R3.Godot/addons/R3.Godot/GodotTimeProvider.cs
@@ -44,7 +44,11 @@ internal sealed class FrameTimer : ITimer, IFrameRunnerWorkItem
     readonly TimerCallback callback;
     readonly object? state;
     readonly GodotFrameProvider frameProvider;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
 
     TimeSpan dueTime;
     TimeSpan period;

--- a/src/R3.LogicLooper/LogicLooperFrameProvider.cs
+++ b/src/R3.LogicLooper/LogicLooperFrameProvider.cs
@@ -13,7 +13,11 @@ public sealed class LogicLooperFrameProvider : FrameProvider, IDisposable
     Task loop;
     internal long timestamp;
     internal TimeSpan deltaTime;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
 
     public LogicLooperFrameProvider(ILogicLooper looper)
     {

--- a/src/R3.LogicLooper/LogicLooperTimerProvider.cs
+++ b/src/R3.LogicLooper/LogicLooperTimerProvider.cs
@@ -28,7 +28,11 @@ internal sealed class FrameTimer : ITimer, IFrameRunnerWorkItem
     readonly TimerCallback callback;
     readonly object? state;
     readonly LogicLooperFrameProvider frameProvider;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
 
     TimeSpan dueTime;
     TimeSpan period;

--- a/src/R3.LogicLooper/R3.LogicLooper.csproj
+++ b/src/R3.LogicLooper/R3.LogicLooper.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1591;1573</NoWarn>
 

--- a/src/R3.Maui/MauiTickerFrameProvider.cs
+++ b/src/R3.Maui/MauiTickerFrameProvider.cs
@@ -6,7 +6,11 @@ namespace R3;
 public class MauiTickerFrameProvider : FrameProvider, IDisposable
 {
     readonly ITicker ticker;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new();
+#endif
     readonly Action timerTick;
 
     FreeListCore<IFrameRunnerWorkItem> runners;

--- a/src/R3.Maui/ObserveOnExtensions.cs
+++ b/src/R3.Maui/ObserveOnExtensions.cs
@@ -43,7 +43,11 @@ internal sealed class ObserveOnDispatcher<T>(Observable<T> source, IDispatcher d
         readonly Action postCallback;
         readonly Observer<T> observer;
         readonly IDispatcher dispatcher;
-        readonly object gate = new();
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
+    readonly object gate = new();
+#endif
         SwapListCore<Notification<T>> list;
         bool running;
 

--- a/src/R3.Maui/R3.Maui.csproj
+++ b/src/R3.Maui/R3.Maui.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1591;1573</NoWarn>
 

--- a/src/R3.MonoGame/MonoGameFrameProvider.cs
+++ b/src/R3.MonoGame/MonoGameFrameProvider.cs
@@ -7,7 +7,11 @@ public class MonoGameFrameProvider : FrameProvider
 {
     public static readonly MonoGameFrameProvider Update = new();
 
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new();
+#endif
     FreeListCore<IFrameRunnerWorkItem> list;
     long frameCount;
     bool disposed;

--- a/src/R3.MonoGame/MonoGameTimeProvider.cs
+++ b/src/R3.MonoGame/MonoGameTimeProvider.cs
@@ -13,7 +13,11 @@ public class MonoGameTimeProvider : TimeProvider, IDisposable
     public GameTime GameTime { get; private set; } = new();
 
     FreeListCore<FrameTimer> list;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new();
+#endif
 
     // frame loop is delayed until first register
     bool running;
@@ -110,7 +114,11 @@ internal sealed class FrameTimer : ITimer
     readonly MonoGameTimeProvider timeProvider;
     readonly TimerCallback callback;
     readonly object? state;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new();
+#endif
 
     TimeSpan dueTime;
     TimeSpan period;
@@ -254,4 +262,3 @@ internal sealed class FrameTimer : ITimer
         return default;
     }
 }
-

--- a/src/R3.MonoGame/R3.MonoGame.csproj
+++ b/src/R3.MonoGame/R3.MonoGame.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
 
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>1701;1702;1591;1573</NoWarn>

--- a/src/R3.Stride/R3.Stride.csproj
+++ b/src/R3.Stride/R3.Stride.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <PackageReadmeFile>README.md</PackageReadmeFile>
 

--- a/src/R3.Stride/StrideFrameProvider.cs
+++ b/src/R3.Stride/StrideFrameProvider.cs
@@ -8,7 +8,11 @@ namespace R3;
 public sealed class StrideFrameProvider : FrameProvider
 {
     FreeListCore<IFrameRunnerWorkItem> list;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
 
     internal StrongBox<double> Delta = default!; // set from Node before running process.
 

--- a/src/R3.Stride/StrideTimeProvider.cs
+++ b/src/R3.Stride/StrideTimeProvider.cs
@@ -39,7 +39,11 @@ internal sealed class StrideFrameTimer : ITimer, IFrameRunnerWorkItem
     TimeSpan period;
     bool isDisposed;
     readonly StrideFrameProvider frameProvider;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
     RunningState runningState;
     double elapsed;
 

--- a/src/R3.WPF/ObserveOnExtensions.cs
+++ b/src/R3.WPF/ObserveOnExtensions.cs
@@ -40,7 +40,12 @@ internal sealed class ObserveOnDispatcher<T>(Observable<T> source, Dispatcher di
         readonly Observer<T> observer;
         readonly Dispatcher dispatcher;
         readonly DispatcherPriority dispatcherPriority;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
+
         SwapListCore<Notification<T>> list;
         bool running;
 

--- a/src/R3.WPF/R3.WPF.csproj
+++ b/src/R3.WPF/R3.WPF.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0-windows;net7.0-windows;net8.0-windows;net472;</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows;net7.0-windows;net8.0-windows;net9.0-windows;net472;</TargetFrameworks>
         <Nullable>enable</Nullable>
         <UseWPF>true</UseWPF>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
 

--- a/src/R3.WPF/WpfRenderingFrameProvider.cs
+++ b/src/R3.WPF/WpfRenderingFrameProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using R3.Collections;
 
 namespace R3;
@@ -8,7 +8,11 @@ public sealed class WpfRenderingFrameProvider : FrameProvider, IDisposable
     bool disposed;
     long frameCount;
     FreeListCore<IFrameRunnerWorkItem> list;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
 
     EventHandler messageLoop;
 

--- a/src/R3.WinForms/R3.WinForms.csproj
+++ b/src/R3.WinForms/R3.WinForms.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0-windows;net8.0-windows;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0-windows;net8.0-windows;net9.0-windows;net472</TargetFrameworks>
         <UseWindowsForms>true</UseWindowsForms>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -16,7 +16,7 @@
     <ItemGroup>
         <None Include="../../Icon.png" Pack="true" PackagePath="/" />
     </ItemGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\R3\R3.csproj" />
     </ItemGroup>

--- a/src/R3.WinForms/WinFormsFrameProvider.cs
+++ b/src/R3.WinForms/WinFormsFrameProvider.cs
@@ -14,7 +14,11 @@ public sealed class WinFormsFrameProvider :
     private bool disposed;
     private long frameCount;
     private FreeListCore<IFrameRunnerWorkItem> list;
+#if NET9_0_OR_GREATER
+    private readonly System.Threading.Lock gate = new();
+#else
     private readonly object gate = new object();
+#endif
     private readonly MessageHook filter;
     private readonly MessageFilter? predicate;
 

--- a/src/R3.WinUI3/WinUI3RenderingFrameProvider.cs
+++ b/src/R3.WinUI3/WinUI3RenderingFrameProvider.cs
@@ -9,7 +9,11 @@ public sealed class WinUI3RenderingFrameProvider : FrameProvider, IDisposable
     bool disposed;
     long frameCount;
     FreeListCore<IFrameRunnerWorkItem> list;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
 
     EventHandler<object> messageLoop;
 

--- a/src/R3/AwaitOperation.cs
+++ b/src/R3/AwaitOperation.cs
@@ -188,7 +188,11 @@ internal abstract class AwaitOperationSwitchObserver<T> : Observer<T>
     CancellationTokenSource cancellationTokenSource;
     readonly bool configureAwait; // continueOnCapturedContext
     readonly bool cancelOnCompleted;
+#if NET9_0_OR_GREATER
+    protected readonly System.Threading.Lock gate = new();
+#else
     protected readonly object gate = new object();
+#endif
     bool running;
     bool completed;
 
@@ -292,7 +296,11 @@ internal abstract class AwaitOperationParallelObserver<T> : Observer<T>
     readonly CancellationTokenSource cancellationTokenSource;
     readonly bool configureAwait; // continueOnCapturedContext
     readonly bool cancelOnCompleted;
+#if NET9_0_OR_GREATER
+    protected readonly System.Threading.Lock gate = new(); // need to use gate.
+#else
     protected readonly object gate = new object(); // need to use gate.
+#endif
 
     protected sealed override bool AutoDisposeOnCompleted => false; // disable auto-dispose
     int runningCount = 0;
@@ -459,7 +467,11 @@ internal abstract class AwaitOperationSequentialParallelObserver<T, TTaskValue> 
 internal abstract class AwaitOperationParallelConcurrentLimitObserver<T>(bool configureAwait, bool cancelOnCompleted, int maxConcurrent) : Observer<T>
 {
     readonly CancellationTokenSource cancellationTokenSource = new();
+#if NET9_0_OR_GREATER
+    protected readonly System.Threading.Lock gate = new(); // need to use gate.
+#else
     protected readonly object gate = new object(); // need to use gate.
+#endif
 
     protected sealed override bool AutoDisposeOnCompleted => false; // disable auto-dispose
 
@@ -555,7 +567,11 @@ internal abstract class AwaitOperationSequentialParallelConcurrentLimitObserver<
     readonly bool configureAwait; // continueOnCapturedContext
     readonly bool cancelOnCompleted;
     readonly int maxConcurrent;
+    #if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
     readonly Channel<(T, ValueTask<TTaskValue>)> channel;
     bool completed;
     int runningCount;

--- a/src/R3/CompositeDisposable.cs
+++ b/src/R3/CompositeDisposable.cs
@@ -7,7 +7,11 @@ namespace R3;
 public sealed class CompositeDisposable : ICollection<IDisposable>, IDisposable
 {
     List<IDisposable?> list; // when removed, set null
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
     bool isDisposed;
     int count;
 

--- a/src/R3/Factories/Concat.cs
+++ b/src/R3/Factories/Concat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace R3;
 
@@ -37,7 +37,11 @@ internal sealed class Concat<T>(IEnumerable<Observable<T>> sources) : Observable
 
         public SerialDisposableCore disposable;
         int id = 0;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Concat(Observer<T> observer, IEnumerable<Observable<T>> sources)
         {

--- a/src/R3/Factories/Merge.cs
+++ b/src/R3/Factories/Merge.cs
@@ -46,7 +46,11 @@ internal sealed class Merge<T>(IEnumerable<Observable<T>> sources) : Observable<
     {
         public Observer<T> observer = observer;
         public SingleAssignmentDisposableCore disposable;
+#if NET9_0_OR_GREATER
+        public readonly System.Threading.Lock gate = new();
+#else
         public readonly object gate = new object();
+#endif
 
         int sourceCount = -1; // not set yet.
         int completeCount;

--- a/src/R3/FrameProvider.cs
+++ b/src/R3/FrameProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public abstract class FrameProvider
 {
@@ -15,7 +15,11 @@ public interface IFrameRunnerWorkItem
 public sealed class FakeFrameProvider : FrameProvider
 {
     long frameCount;
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
     FreeListCore<IFrameRunnerWorkItem> list;
 
     public FakeFrameProvider()

--- a/src/R3/Operators/Chunk.cs
+++ b/src/R3/Operators/Chunk.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace R3;
 
@@ -247,7 +247,11 @@ internal sealed class ChunkTimeCount<T>(Observable<T> source, TimeSpan timeSpan,
         readonly int count;
         readonly TimeSpan timeSpan;
         readonly TimeProvider timeProvider;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         ITimer? timer;
         T[] buffer;
         int index;

--- a/src/R3/Operators/ChunkFrame.cs
+++ b/src/R3/Operators/ChunkFrame.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -119,7 +119,11 @@ internal sealed class ChunkFrameCount<T>(Observable<T> source, int frameCount, i
         readonly Observer<T[]> observer;
         readonly int periodFrame;
         readonly int count;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly FrameProvider frameProvider;
         bool running;
         T[] buffer;

--- a/src/R3/Operators/CombineLatest.cs
+++ b/src/R3/Operators/CombineLatest.cs
@@ -244,8 +244,11 @@ internal sealed class CombineLatest<T1, T2, TResult>(
         readonly Func<T1, T2, TResult> resultSelector;
         readonly CombineLatestObserver<T1> observer1;
         readonly CombineLatestObserver<T2> observer2;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -376,8 +379,11 @@ internal sealed class CombineLatest<T1, T2, T3, TResult>(
         readonly CombineLatestObserver<T1> observer1;
         readonly CombineLatestObserver<T2> observer2;
         readonly CombineLatestObserver<T3> observer3;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -516,8 +522,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, TResult>(
         readonly CombineLatestObserver<T2> observer2;
         readonly CombineLatestObserver<T3> observer3;
         readonly CombineLatestObserver<T4> observer4;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -664,8 +673,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, TResult>(
         readonly CombineLatestObserver<T3> observer3;
         readonly CombineLatestObserver<T4> observer4;
         readonly CombineLatestObserver<T5> observer5;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -820,8 +832,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, TResult>(
         readonly CombineLatestObserver<T4> observer4;
         readonly CombineLatestObserver<T5> observer5;
         readonly CombineLatestObserver<T6> observer6;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -984,8 +999,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(
         readonly CombineLatestObserver<T5> observer5;
         readonly CombineLatestObserver<T6> observer6;
         readonly CombineLatestObserver<T7> observer7;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -1156,8 +1174,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
         readonly CombineLatestObserver<T6> observer6;
         readonly CombineLatestObserver<T7> observer7;
         readonly CombineLatestObserver<T8> observer8;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -1336,8 +1357,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>
         readonly CombineLatestObserver<T7> observer7;
         readonly CombineLatestObserver<T8> observer8;
         readonly CombineLatestObserver<T9> observer9;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -1524,8 +1548,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TRe
         readonly CombineLatestObserver<T8> observer8;
         readonly CombineLatestObserver<T9> observer9;
         readonly CombineLatestObserver<T10> observer10;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -1720,8 +1747,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11
         readonly CombineLatestObserver<T9> observer9;
         readonly CombineLatestObserver<T10> observer10;
         readonly CombineLatestObserver<T11> observer11;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -1924,8 +1954,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11
         readonly CombineLatestObserver<T10> observer10;
         readonly CombineLatestObserver<T11> observer11;
         readonly CombineLatestObserver<T12> observer12;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -2136,8 +2169,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11
         readonly CombineLatestObserver<T11> observer11;
         readonly CombineLatestObserver<T12> observer12;
         readonly CombineLatestObserver<T13> observer13;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -2356,8 +2392,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11
         readonly CombineLatestObserver<T12> observer12;
         readonly CombineLatestObserver<T13> observer13;
         readonly CombineLatestObserver<T14> observer14;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 
@@ -2584,8 +2623,11 @@ internal sealed class CombineLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11
         readonly CombineLatestObserver<T13> observer13;
         readonly CombineLatestObserver<T14> observer14;
         readonly CombineLatestObserver<T15> observer15;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 

--- a/src/R3/Operators/CombineLatest.tt
+++ b/src/R3/Operators/CombineLatest.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
@@ -56,8 +56,12 @@ internal sealed class CombineLatest<<#= generateT(i) #>, TResult>(
         readonly Func<<#= generateT(i) #>, TResult> resultSelector;
 <# for (var j = 1; j <= i; j++ ) { #>
         readonly CombineLatestObserver<T<#= j #>> observer<#= j #>;
-<# } #>        
+<# } #>
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool hasValueAll;
         int completedCount;
 

--- a/src/R3/Operators/Debounce.cs
+++ b/src/R3/Operators/Debounce.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -32,7 +32,11 @@ internal sealed class Debounce<T>(Observable<T> source, TimeSpan timeSpan, TimeP
         readonly Observer<T> observer;
         readonly TimeSpan timeSpan;
         readonly ITimer timer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         T? latestValue;
         bool hasvalue;
         int timerId;
@@ -109,7 +113,11 @@ internal sealed class DebounceSelector<T>(Observable<T> source, Func<T, Cancella
 
     sealed class _Debounce(Observer<T> observer, Func<T, CancellationToken, ValueTask> throttleDurationSelector, bool configureAwait) : Observer<T>
     {
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         T? latestValue;
         bool hasValue;
         bool isRunning;

--- a/src/R3/Operators/DebounceFrame.cs
+++ b/src/R3/Operators/DebounceFrame.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -25,7 +25,11 @@ internal sealed class DebounceFrame<T>(Observable<T> source, int frameCount, Fra
     {
         readonly Observer<T> observer;
         readonly int frameCount;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly FrameProvider frameProvider;
         T? latestValue;
         bool hasvalue;

--- a/src/R3/Operators/Multicast.cs
+++ b/src/R3/Operators/Multicast.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -77,7 +77,11 @@ public static partial class ObservableExtensions
 
 internal sealed class Multicast<T>(Observable<T> source, ISubject<T> subject) : ConnectableObservable<T>
 {
+    #if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
     Connection? connection;
 
     public override IDisposable Connect()

--- a/src/R3/Operators/ObserveOn.cs
+++ b/src/R3/Operators/ObserveOn.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Concurrent;
+using System.Collections.Concurrent;
 
 namespace R3;
 
@@ -54,7 +54,11 @@ internal sealed class ObserveOnSynchronizationContext<T>(Observable<T> source, S
 
         readonly Observer<T> observer;
         readonly SynchronizationContext synchronizationContext;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         SwapListCore<Notification<T>> list;
         bool running;
 
@@ -413,7 +417,11 @@ internal sealed class ObserveOnFrameProvider<T>(Observable<T> source, FrameProvi
     {
         readonly Observer<T> observer;
         readonly FrameProvider frameProvider;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         SwapListCore<Notification<T>> list;
         bool running;
 

--- a/src/R3/Operators/RefCount.cs
+++ b/src/R3/Operators/RefCount.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -10,7 +10,11 @@ public static partial class ObservableExtensions
 
 internal sealed class RefCount<T>(ConnectableObservable<T> source) : Observable<T>
 {
+    #if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
     int refCount = 0;
     IDisposable? connection;
 

--- a/src/R3/Operators/SelectMany.cs
+++ b/src/R3/Operators/SelectMany.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -40,7 +40,11 @@ internal sealed class SelectMany<TSource, TCollection, TResult>(Observable<TSour
         readonly Func<TSource, Observable<TCollection>> collectionSelector = collectionSelector;
         readonly Func<TSource, TCollection, TResult> resultSelector = resultSelector;
         readonly CompositeDisposable compositeDisposable = new();
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool isStopped;
 
         protected override bool AutoDisposeOnCompleted => false;
@@ -161,7 +165,11 @@ internal sealed class SelectManyIndexed<TSource, TCollection, TResult>(Observabl
         readonly Func<TSource, int, Observable<TCollection>> collectionSelector = collectionSelector;
         readonly Func<TSource, int, TCollection, int, TResult> resultSelector = resultSelector;
         readonly CompositeDisposable compositeDisposable = new();
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool isStopped;
         int index = 0;
 

--- a/src/R3/Operators/Switch.cs
+++ b/src/R3/Operators/Switch.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -18,7 +18,11 @@ internal sealed class Switch<T>(Observable<Observable<T>> sources) : Observable<
     sealed class _Switch(Observer<T> observer) : Observer<Observable<T>>
     {
         public Observer<T> observer = observer;
+#if NET9_0_OR_GREATER
+        public readonly System.Threading.Lock gate = new();
+#else
         public readonly object gate = new object();
+#endif
 
         SerialDisposableCore subscription;
         public ulong id;

--- a/src/R3/Operators/Take.cs
+++ b/src/R3/Operators/Take.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -88,7 +88,11 @@ internal sealed class TakeTime<T>(Observable<T> source, TimeSpan duration, TimeP
 
         readonly Observer<T> observer;
         readonly ITimer timer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _TakeTime(Observer<T> observer, TimeSpan duration, TimeProvider timeProvider)
         {
@@ -145,7 +149,11 @@ internal sealed class TakeFrame<T>(Observable<T> source, int frameCount, FramePr
     {
         readonly Observer<T> observer;
         long remaining;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _TakeFrame(Observer<T> observer, int frameCount, FrameProvider frameProvider)
         {

--- a/src/R3/Operators/TakeLast.cs
+++ b/src/R3/Operators/TakeLast.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -106,7 +106,11 @@ internal sealed class TakeLastTime<T>(Observable<T> source, TimeSpan duration, T
     sealed class _TakeLastTime : Observer<T>, IDisposable
     {
         readonly Observer<T> observer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly Queue<(long timestamp, T value)> queue = new();
         readonly TimeSpan duration;
         readonly TimeProvider timeProvider;
@@ -188,7 +192,11 @@ internal sealed class TakeLastFrame<T>(Observable<T> source, int frameCount, Fra
     sealed class _TakeLastFrame : Observer<T>, IDisposable
     {
         readonly Observer<T> observer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly Queue<(long frameCount, T value)> queue = new();
         readonly int frameCount;
         readonly FrameProvider frameProvider;

--- a/src/R3/Operators/ThrottleFirst.cs
+++ b/src/R3/Operators/ThrottleFirst.cs
@@ -1,4 +1,4 @@
-﻿namespace R3;
+namespace R3;
 
 public static partial class ObservableExtensions
 {
@@ -37,7 +37,11 @@ internal sealed class ThrottleFirst<T>(Observable<T> source, TimeSpan timeSpan, 
         readonly Observer<T> observer;
         readonly ITimer timer;
         readonly TimeSpan timeSpan;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         bool closing;
 
         public _ThrottleFirst(Observer<T> observer, TimeSpan timeSpan, TimeProvider timeProvider)
@@ -95,7 +99,11 @@ internal sealed class ThrottleFirstAsyncSampler<T>(Observable<T> source, Func<T,
 
     sealed class _ThrottleFirst(Observer<T> observer, Func<T, CancellationToken, ValueTask> sampler, bool configureAwait) : Observer<T>
     {
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly CancellationTokenSource cancellationTokenSource = new();
         bool closing;
 
@@ -163,7 +171,11 @@ internal sealed class ThrottleFirstObservableSampler<T, TSample>(Observable<T> s
     sealed class _ThrottleFirst : Observer<T>
     {
         readonly Observer<T> observer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly IDisposable samplerSubscription;
         bool closing;
 

--- a/src/R3/Operators/ThrottleFirstFrame.cs
+++ b/src/R3/Operators/ThrottleFirstFrame.cs
@@ -26,7 +26,11 @@ internal sealed class ThrottleFirstFrame<T>(Observable<T> source, int frameCount
         readonly Observer<T> observer;
         readonly int frameCount;
         readonly FrameProvider frameProvider;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         int currentFrame;
         bool closing;
 

--- a/src/R3/Operators/ThrottleFirstLast.cs
+++ b/src/R3/Operators/ThrottleFirstLast.cs
@@ -37,7 +37,11 @@ internal sealed class ThrottleFirstLast<T>(Observable<T> source, TimeSpan interv
         readonly Observer<T> observer;
         readonly TimeSpan interval;
         readonly ITimer timer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         T? lastValue;
         bool hasValue;
         bool timerIsRunning;
@@ -109,7 +113,11 @@ internal sealed class ThrottleFirstLastAsyncSampler<T>(Observable<T> source, Fun
 
     sealed class _ThrottleFirstLast(Observer<T> observer, Func<T, CancellationToken, ValueTask> sampler, bool configureAwait) : Observer<T>
     {
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly CancellationTokenSource cancellationTokenSource = new();
         T? lastValue;
         bool hasValue;
@@ -190,7 +198,11 @@ internal sealed class ThrottleFirstLastObservableSampler<T, TSample>(Observable<
     sealed class _ThrottleFirstLast : Observer<T>
     {
         readonly Observer<T> observer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly IDisposable samplerSubscription;
         T? lastValue;
         bool hasValue;

--- a/src/R3/Operators/ThrottleFirstLastFrame.cs
+++ b/src/R3/Operators/ThrottleFirstLastFrame.cs
@@ -25,7 +25,11 @@ internal sealed class ThrottleFirstLastFrame<T>(Observable<T> source, int frameC
         readonly Observer<T> observer;
         readonly FrameProvider frameProvider;
         readonly int frameCount;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         T? lastValue;
         bool hasValue;
         int currentFrame;

--- a/src/R3/Operators/ThrottleLast.cs
+++ b/src/R3/Operators/ThrottleLast.cs
@@ -37,7 +37,11 @@ internal sealed class ThrottleLast<T>(Observable<T> source, TimeSpan interval, T
         readonly Observer<T> observer;
         readonly TimeSpan interval;
         readonly ITimer timer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         T? lastValue;
         bool hasValue;
 
@@ -102,7 +106,11 @@ internal sealed class ThrottleLastAsyncSampler<T>(Observable<T> source, Func<T, 
 
     sealed class _ThrottleLast(Observer<T> observer, Func<T, CancellationToken, ValueTask> sampler, bool configureAwait) : Observer<T>
     {
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly CancellationTokenSource cancellationTokenSource = new();
         T? lastValue;
         bool isRunning;
@@ -173,7 +181,11 @@ internal sealed class ThrottleLastObservableSampler<T, TSample>(Observable<T> so
     sealed class _ThrottleLast : Observer<T>
     {
         readonly Observer<T> observer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         readonly IDisposable samplerSubscription;
         T? lastValue;
         bool hasValue;

--- a/src/R3/Operators/ThrottleLastFrame.cs
+++ b/src/R3/Operators/ThrottleLastFrame.cs
@@ -27,7 +27,11 @@ internal sealed class ThrottleLastFrame<T>(Observable<T> source, int frameCount,
         readonly Observer<T> observer;
         readonly FrameProvider frameProvider;
         readonly int frameCount;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         T? lastValue;
         int currentFrame;
         bool running;

--- a/src/R3/Operators/Timeout.cs
+++ b/src/R3/Operators/Timeout.cs
@@ -27,7 +27,11 @@ internal sealed class Timeout<T>(Observable<T> source, TimeSpan dueTime, TimePro
         readonly Observer<T> observer;
         readonly TimeSpan timeSpan;
         readonly ITimer timer;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         int timerId;
 
         public _Timeout(Observer<T> observer, TimeSpan timeSpan, TimeProvider timeProvider)

--- a/src/R3/Operators/TimeoutFrame.cs
+++ b/src/R3/Operators/TimeoutFrame.cs
@@ -24,7 +24,11 @@ internal sealed class TimeoutFrame<T>(Observable<T> source, int frameCount, Fram
     {
         readonly Observer<T> observer;
         readonly int frameCount;
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
         int currentFrame;
 
         public _TimeoutFrame(Observer<T> observer, int frameCount, FrameProvider frameProvider)

--- a/src/R3/Operators/Zip.cs
+++ b/src/R3/Operators/Zip.cs
@@ -239,8 +239,11 @@ internal sealed class Zip<T1, T2, TResult>(
         readonly Func<T1, T2, TResult> resultSelector;
         readonly ZipObserver<T1> observer1;
         readonly ZipObserver<T2> observer2;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -368,8 +371,11 @@ internal sealed class Zip<T1, T2, T3, TResult>(
         readonly ZipObserver<T1> observer1;
         readonly ZipObserver<T2> observer2;
         readonly ZipObserver<T3> observer3;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -505,8 +511,11 @@ internal sealed class Zip<T1, T2, T3, T4, TResult>(
         readonly ZipObserver<T2> observer2;
         readonly ZipObserver<T3> observer3;
         readonly ZipObserver<T4> observer4;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -650,8 +659,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, TResult>(
         readonly ZipObserver<T3> observer3;
         readonly ZipObserver<T4> observer4;
         readonly ZipObserver<T5> observer5;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -803,8 +815,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, TResult>(
         readonly ZipObserver<T4> observer4;
         readonly ZipObserver<T5> observer5;
         readonly ZipObserver<T6> observer6;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -964,8 +979,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, TResult>(
         readonly ZipObserver<T5> observer5;
         readonly ZipObserver<T6> observer6;
         readonly ZipObserver<T7> observer7;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -1133,8 +1151,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
         readonly ZipObserver<T6> observer6;
         readonly ZipObserver<T7> observer7;
         readonly ZipObserver<T8> observer8;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -1310,8 +1331,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
         readonly ZipObserver<T7> observer7;
         readonly ZipObserver<T8> observer8;
         readonly ZipObserver<T9> observer9;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -1495,8 +1519,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult>(
         readonly ZipObserver<T8> observer8;
         readonly ZipObserver<T9> observer9;
         readonly ZipObserver<T10> observer10;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -1688,8 +1715,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult>
         readonly ZipObserver<T9> observer9;
         readonly ZipObserver<T10> observer10;
         readonly ZipObserver<T11> observer11;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -1889,8 +1919,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TRe
         readonly ZipObserver<T10> observer10;
         readonly ZipObserver<T11> observer11;
         readonly ZipObserver<T12> observer12;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -2098,8 +2131,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
         readonly ZipObserver<T11> observer11;
         readonly ZipObserver<T12> observer12;
         readonly ZipObserver<T13> observer13;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -2315,8 +2351,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
         readonly ZipObserver<T12> observer12;
         readonly ZipObserver<T13> observer13;
         readonly ZipObserver<T14> observer14;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,
@@ -2540,8 +2579,11 @@ internal sealed class Zip<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13
         readonly ZipObserver<T13> observer13;
         readonly ZipObserver<T14> observer14;
         readonly ZipObserver<T15> observer15;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,

--- a/src/R3/Operators/Zip.tt
+++ b/src/R3/Operators/Zip.tt
@@ -53,8 +53,12 @@ internal sealed class Zip<<#= generateT(i) #>, TResult>(
         readonly Func<<#= generateT(i) #>, TResult> resultSelector;
 <# for (var j = 1; j <= i; j++ ) { #>
         readonly ZipObserver<T<#= j #>> observer<#= j #>;
-<# } #>        
+<# } #>
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _Zip(
             Observer<TResult> observer,

--- a/src/R3/Operators/ZipLatest.cs
+++ b/src/R3/Operators/ZipLatest.cs
@@ -239,8 +239,11 @@ internal sealed class ZipLatest<T1, T2, TResult>(
         readonly Func<T1, T2, TResult> resultSelector;
         readonly ZipLatestObserver<T1> observer1;
         readonly ZipLatestObserver<T2> observer2;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -277,7 +280,7 @@ internal sealed class ZipLatest<T1, T2, TResult>(
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -371,8 +374,11 @@ internal sealed class ZipLatest<T1, T2, T3, TResult>(
         readonly ZipLatestObserver<T1> observer1;
         readonly ZipLatestObserver<T2> observer2;
         readonly ZipLatestObserver<T3> observer3;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -413,7 +419,7 @@ internal sealed class ZipLatest<T1, T2, T3, TResult>(
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -511,8 +517,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, TResult>(
         readonly ZipLatestObserver<T2> observer2;
         readonly ZipLatestObserver<T3> observer3;
         readonly ZipLatestObserver<T4> observer4;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -557,7 +566,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, TResult>(
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -659,8 +668,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, TResult>(
         readonly ZipLatestObserver<T3> observer3;
         readonly ZipLatestObserver<T4> observer4;
         readonly ZipLatestObserver<T5> observer5;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -709,7 +721,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, TResult>(
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -815,8 +827,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, TResult>(
         readonly ZipLatestObserver<T4> observer4;
         readonly ZipLatestObserver<T5> observer5;
         readonly ZipLatestObserver<T6> observer6;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -869,7 +884,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, TResult>(
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -979,8 +994,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(
         readonly ZipLatestObserver<T5> observer5;
         readonly ZipLatestObserver<T6> observer6;
         readonly ZipLatestObserver<T7> observer7;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -1037,7 +1055,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, TResult>(
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -1151,8 +1169,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
         readonly ZipLatestObserver<T6> observer6;
         readonly ZipLatestObserver<T7> observer7;
         readonly ZipLatestObserver<T8> observer8;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -1213,7 +1234,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, TResult>(
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue(), observer8.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted || observer8.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -1331,8 +1352,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
         readonly ZipLatestObserver<T7> observer7;
         readonly ZipLatestObserver<T8> observer8;
         readonly ZipLatestObserver<T9> observer9;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -1397,7 +1421,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult>(
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue(), observer8.GetValue(), observer9.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted || observer8.IsCompleted || observer9.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -1519,8 +1543,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult
         readonly ZipLatestObserver<T8> observer8;
         readonly ZipLatestObserver<T9> observer9;
         readonly ZipLatestObserver<T10> observer10;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -1589,7 +1616,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue(), observer8.GetValue(), observer9.GetValue(), observer10.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted || observer8.IsCompleted || observer9.IsCompleted || observer10.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -1715,8 +1742,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TR
         readonly ZipLatestObserver<T9> observer9;
         readonly ZipLatestObserver<T10> observer10;
         readonly ZipLatestObserver<T11> observer11;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -1789,7 +1819,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TR
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue(), observer8.GetValue(), observer9.GetValue(), observer10.GetValue(), observer11.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted || observer8.IsCompleted || observer9.IsCompleted || observer10.IsCompleted || observer11.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -1919,8 +1949,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
         readonly ZipLatestObserver<T10> observer10;
         readonly ZipLatestObserver<T11> observer11;
         readonly ZipLatestObserver<T12> observer12;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -1997,7 +2030,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue(), observer8.GetValue(), observer9.GetValue(), observer10.GetValue(), observer11.GetValue(), observer12.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted || observer8.IsCompleted || observer9.IsCompleted || observer10.IsCompleted || observer11.IsCompleted || observer12.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -2131,8 +2164,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
         readonly ZipLatestObserver<T11> observer11;
         readonly ZipLatestObserver<T12> observer12;
         readonly ZipLatestObserver<T13> observer13;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -2213,7 +2249,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue(), observer8.GetValue(), observer9.GetValue(), observer10.GetValue(), observer11.GetValue(), observer12.GetValue(), observer13.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted || observer8.IsCompleted || observer9.IsCompleted || observer10.IsCompleted || observer11.IsCompleted || observer12.IsCompleted || observer13.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -2351,8 +2387,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
         readonly ZipLatestObserver<T12> observer12;
         readonly ZipLatestObserver<T13> observer13;
         readonly ZipLatestObserver<T14> observer14;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -2437,7 +2476,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue(), observer8.GetValue(), observer9.GetValue(), observer10.GetValue(), observer11.GetValue(), observer12.GetValue(), observer13.GetValue(), observer14.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted || observer8.IsCompleted || observer9.IsCompleted || observer10.IsCompleted || observer11.IsCompleted || observer12.IsCompleted || observer13.IsCompleted || observer14.IsCompleted)
                 {
                     observer.OnCompleted();
@@ -2579,8 +2618,11 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
         readonly ZipLatestObserver<T13> observer13;
         readonly ZipLatestObserver<T14> observer14;
         readonly ZipLatestObserver<T15> observer15;
-        
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -2669,7 +2711,7 @@ internal sealed class ZipLatest<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T1
             {
                 var result = resultSelector(observer1.GetValue(), observer2.GetValue(), observer3.GetValue(), observer4.GetValue(), observer5.GetValue(), observer6.GetValue(), observer7.GetValue(), observer8.GetValue(), observer9.GetValue(), observer10.GetValue(), observer11.GetValue(), observer12.GetValue(), observer13.GetValue(), observer14.GetValue(), observer15.GetValue());
                 observer.OnNext(result);
-                
+
                 if (observer1.IsCompleted || observer2.IsCompleted || observer3.IsCompleted || observer4.IsCompleted || observer5.IsCompleted || observer6.IsCompleted || observer7.IsCompleted || observer8.IsCompleted || observer9.IsCompleted || observer10.IsCompleted || observer11.IsCompleted || observer12.IsCompleted || observer13.IsCompleted || observer14.IsCompleted || observer15.IsCompleted)
                 {
                     observer.OnCompleted();

--- a/src/R3/Operators/ZipLatest.tt
+++ b/src/R3/Operators/ZipLatest.tt
@@ -53,8 +53,12 @@ internal sealed class ZipLatest<<#= generateT(i) #>, TResult>(
         readonly Func<<#= generateT(i) #>, TResult> resultSelector;
 <# for (var j = 1; j <= i; j++ ) { #>
         readonly ZipLatestObserver<T<#= j #>> observer<#= j #>;
-<# } #>        
+<# } #>
+#if NET9_0_OR_GREATER
+        readonly System.Threading.Lock gate = new();
+#else
         readonly object gate = new object();
+#endif
 
         public _ZipLatest(
             Observer<TResult> observer,
@@ -95,7 +99,7 @@ internal sealed class ZipLatest<<#= generateT(i) #>, TResult>(
             {
                 var result = resultSelector(<#= generateValue(i) #>);
                 observer.OnNext(result);
-                
+
                 if (<#= generateIsCompletedOr(i) #>)
                 {
                     observer.OnCompleted();

--- a/src/R3/R3.csproj
+++ b/src/R3/R3.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net9.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>12</LangVersion>
+        <LangVersion>13</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
         <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/R3/TimerFrameProvider.cs
+++ b/src/R3/TimerFrameProvider.cs
@@ -4,7 +4,11 @@ public sealed class TimerFrameProvider : FrameProvider, IDisposable
 {
     static readonly TimerCallback timerCallback = Run;
 
+#if NET9_0_OR_GREATER
+    readonly System.Threading.Lock gate = new();
+#else
     readonly object gate = new object();
+#endif
     long frameCount;
     bool disposed;
     FreeListCore<IFrameRunnerWorkItem> list;

--- a/tests/R3.Tests/R3.Tests.csproj
+++ b/tests/R3.Tests/R3.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
Adds support using `System.Threading.Lock` on platforms that support .NET 9 and C# 13. All unit tests continue to pass.  