### PR TITLE
Fix `ToReadOnlyReactiveProperty()` behavior

### DIFF
--- a/src/R3/ReactivePropertyExtensions.cs
+++ b/src/R3/ReactivePropertyExtensions.cs
@@ -7,19 +7,23 @@ namespace R3;
 
 public static class ReactivePropertyExtensions
 {
-    public static ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty<T>(this Observable<T> source, T initialValue = default!)
-    {
-        return source.ToReadOnlyReactiveProperty(EqualityComparer<T>.Default, initialValue);
-    }
-
-    public static ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty<T>(this Observable<T> source, IEqualityComparer<T>? equalityComparer, T initialValue = default!)
+    public static ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty<T>(this Observable<T> source)
     {
         if (source is ReadOnlyReactiveProperty<T> rrp)
         {
             return rrp;
         }
 
-        // allow to cast ReactiveProperty<T>
+        return source.ToReadOnlyReactiveProperty(EqualityComparer<T>.Default, default!);
+    }
+
+    public static ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty<T>(this Observable<T> source, T initialValue)
+    {
+        return source.ToReadOnlyReactiveProperty(EqualityComparer<T>.Default, initialValue);
+    }
+
+    public static ReadOnlyReactiveProperty<T> ToReadOnlyReactiveProperty<T>(this Observable<T> source, IEqualityComparer<T>? equalityComparer, T initialValue = default!)
+    {
         return new ConnectedReactiveProperty<T>(source, initialValue, equalityComparer);
     }
 


### PR DESCRIPTION
The current code path of `ToReadOnlyReactiveProperty()` is as follows.

1. When calling `ToReadOnlyReactiveProperty()` on `ReadOnlyReactiveProperty<T>`, the instance method is called. This returns the instance itself.

2. When calling `ToReadOnlyReactiveProperty()` on `Observable<T>`, the extension method is called. Here, if the source is `ReadOnlyReactiveProperty<T>`, the instance is returned as is.

The problem here is that if the source is `ReadOnlyReactiveProperty<T>`, even if `initialValue` and `equalityComparer` are specified as arguments, they are ignored. This is unintuitive and not desirable behavior.

Therefore, this PR changes the code path as follows.

1. When calling `ToReadOnlyReactiveProperty()` on `ReadOnlyReactiveProperty<T>`, the instance method is called.

2. When calling `ToReadOnlyReactiveProperty()` on `Observable<T>`, the extension method is called. Here, if source is `ReadOnlyReactiveProperty<T>` **and it is the overload without arguments,** the instance is returned as is.

This ensures that an instance is always created when an argument is specified, so it will work correctly even if source is `ReadOnlyReactiveProperty<T>`.