### PR TITLE
Fix DebounceFrame and ThrottleLastFrame behavior on re-entry

### DIFF
--- a/src/R3/Operators/DebounceFrame.cs
+++ b/src/R3/Operators/DebounceFrame.cs
@@ -28,7 +28,7 @@ internal sealed class DebounceFrame<T>(Observable<T> source, int frameCount, Fra
         readonly object gate = new object();
         readonly FrameProvider frameProvider;
         T? latestValue;
-        bool hasvalue;
+        bool hasValue;
         int currentFrame;
         bool isRunning;
 
@@ -44,7 +44,7 @@ internal sealed class DebounceFrame<T>(Observable<T> source, int frameCount, Fra
             lock (gate)
             {
                 latestValue = value;
-                hasvalue = true;
+                hasValue = true;
                 currentFrame = 0;
 
                 if (!isRunning)
@@ -64,10 +64,10 @@ internal sealed class DebounceFrame<T>(Observable<T> source, int frameCount, Fra
         {
             lock (gate)
             {
-                if (hasvalue)
+                if (hasValue)
                 {
                     observer.OnNext(latestValue!);
-                    hasvalue = false;
+                    hasValue = false;
                     latestValue = default;
                 }
             }
@@ -80,15 +80,16 @@ internal sealed class DebounceFrame<T>(Observable<T> source, int frameCount, Fra
 
             lock (gate)
             {
-                if (hasvalue)
+                if (hasValue)
                 {
                     if (++currentFrame == frameCount)
                     {
-                        observer.OnNext(latestValue!);
-                        hasvalue = false;
+                        var value = latestValue!;
+                        hasValue = false;
                         latestValue = default;
                         currentFrame = 0;
                         isRunning = false;
+                        observer.OnNext(value);
                         return false;
                     }
                 }

--- a/src/R3/Operators/ThrottleLastFrame.cs
+++ b/src/R3/Operators/ThrottleLastFrame.cs
@@ -72,9 +72,10 @@ internal sealed class ThrottleLastFrame<T>(Observable<T> source, int frameCount,
             {
                 if (++currentFrame == frameCount)
                 {
-                    observer.OnNext(lastValue!);
+                    var value = lastValue!;
                     lastValue = default;
                     running = false;
+                    observer.OnNext(value);
                     return false;
                 }
             }

--- a/tests/R3.Tests/OperatorTests/DebounceThrottleFirstThrottleLastTest.cs
+++ b/tests/R3.Tests/OperatorTests/DebounceThrottleFirstThrottleLastTest.cs
@@ -445,4 +445,44 @@ public class DebounceThrottleFirstThrottleLastTest
 
         list.AssertIsCompleted();
     }
+
+
+    // + Publish from OnNext
+    [Fact]
+    public void DebounceFrameReentry()
+    {
+        var frameProvider = new FakeFrameProvider();
+
+        var publisher = new Subject<int>();
+        var list = publisher.DebounceFrame(3, frameProvider).Do(_ => publisher.OnNext(2)).ToLiveList();
+
+        publisher.OnNext(1);
+        list.AssertEqual([]);
+
+        frameProvider.Advance(3);
+
+        list.AssertEqual([1]);
+
+        frameProvider.Advance(3);
+        list.AssertEqual([1, 2]);
+    }
+
+    [Fact]
+    public void ThrottleLastFrameReentry()
+    {
+        var frameProvider = new FakeFrameProvider();
+
+        var publisher = new Subject<int>();
+        var list = publisher.ThrottleLastFrame(3, frameProvider).Do(_ => publisher.OnNext(2)).ToLiveList();
+
+        publisher.OnNext(1);
+        list.AssertEqual([]);
+
+        frameProvider.Advance(3);
+
+        list.AssertEqual([1]);
+
+        frameProvider.Advance(3);
+        list.AssertEqual([1, 2]);
+    }
 }


### PR DESCRIPTION
Previously, if DebounceFrame.OnNext was invoked synchronously during _DebounceFrame.observer.OnNext, the incoming value would be ignored. ThrottleLastFrame had the same problem. Below is a code sample illustrating this issue:
```
var publisher = new Subject<int>();

publisher.DebounceFrame(1)
    .Subscribe(value =>
    {
        if (value == 1)
        {
            publisher.OnNext(2);
        } else if (value == 2)
        {
            // We'll never get here
        }
    });
    
publisher.OnNext(1);
```
