### PR TITLE
Add support for state in Defer factory method

### DIFF
--- a/docs/reference_factory.md
+++ b/docs/reference_factory.md
@@ -26,7 +26,8 @@
 | **CreateFrom**(`Func<CancellationToken, IAsyncEnumerable<T>>` factory) | `Observable<T>` | 
 | **CreateFrom**(`TState` state, `Func<CancellationToken, TState, IAsyncEnumerable<T>>` factory) | `Observable<T>` | 
 | **Defer**(`Func<Observable<T>>` observableFactory, `Boolean` rawObserver = false) | `Observable<T>` | 
-| **Empty**() | `Observable<T>` | 
+| **Defer**(`TState` state, `Func<TState, Observable<T>>` observableFactory, `Boolean` rawObserver = false) | `Observable<T>` |
+| **Empty**() | `Observable<T>` |
 | **Empty**(`TimeProvider` timeProvider) | `Observable<T>` | 
 | **Empty**(`TimeSpan` dueTime, `TimeProvider` timeProvider) | `Observable<T>` | 
 | **EveryUpdate**() | `Observable<Unit>` | 

--- a/src/R3/Factories/Defer.cs
+++ b/src/R3/Factories/Defer.cs
@@ -6,6 +6,11 @@ public static partial class Observable
     {
         return new Defer<T>(observableFactory, rawObserver);
     }
+
+    public static Observable<T> Defer<T, TState>(TState state, Func<TState, Observable<T>> observableFactory, bool rawObserver = false)
+    {
+        return new Defer<T, TState>(state, observableFactory, rawObserver);
+    }
 }
 
 internal sealed class Defer<T>(Func<Observable<T>> observableFactory, bool rawObserver) : Observable<T>
@@ -16,6 +21,25 @@ internal sealed class Defer<T>(Func<Observable<T>> observableFactory, bool rawOb
         try
         {
             observable = observableFactory();
+        }
+        catch (Exception ex)
+        {
+            observer.OnCompleted(ex); // when failed, return Completed(Error)
+            return Disposable.Empty;
+        }
+
+        return observable.Subscribe(rawObserver ? observer : observer.Wrap());
+    }
+}
+
+internal sealed class Defer<T, TState>(TState state, Func<TState, Observable<T>> observableFactory, bool rawObserver) : Observable<T>
+{
+    protected override IDisposable SubscribeCore(Observer<T> observer)
+    {
+        var observable = default(Observable<T>);
+        try
+        {
+            observable = observableFactory(state);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Add a new overload of `Defer` and implementation to accept a state parameter. This enables to pass a state and avoid a closure.