### PR TITLE
force continuations to run async

### DIFF
--- a/src/R3/Internal/Shims/TaskExtensions.cs
+++ b/src/R3/Internal/Shims/TaskExtensions.cs
@@ -6,7 +6,7 @@ internal static class TaskExtensions
 {
     internal static Task<T> WaitAsync<T>(this Task<T> task, CancellationToken cancellationToken)
     {
-        var tcs = new TaskCompletionSource<T>();
+        var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
         var registration = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
 
         task.ContinueWith(t =>

--- a/src/R3/Internal/TaskObserverBase.cs
+++ b/src/R3/Internal/TaskObserverBase.cs
@@ -16,7 +16,7 @@ internal abstract class TaskObserverBase<T, TTask> : Observer<T>
 
     public TaskObserverBase(CancellationToken cancellationToken)
     {
-        this.tcs = new TaskCompletionSource<TTask>();
+        this.tcs = new TaskCompletionSource<TTask>(TaskCreationOptions.RunContinuationsAsynchronously);
         this.cancellationToken = cancellationToken;
 
         if (cancellationToken.CanBeCanceled)


### PR DESCRIPTION
I noticed that `TaskObserverBase` internally uses a `TaskCompletionSource` without passing `TaskCreationOptions.RunContinuationsAsynchronously`.

https://devblogs.microsoft.com/premier-developer/the-danger-of-taskcompletionsourcet-class/

https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#always-create-taskcompletionsourcet-with-taskcreationoptionsruncontinuationsasynchronously