### PR TITLE
Fix subscribe methods not using latest registered exception handler

### DIFF
--- a/src/R3/ObservableSubscribeExtensions.cs
+++ b/src/R3/ObservableSubscribeExtensions.cs
@@ -13,13 +13,13 @@ public static class ObservableSubscribeExtensions
     [DebuggerStepThrough]
     public static IDisposable Subscribe<T>(this Observable<T> source, Action<T> onNext)
     {
-        return source.Subscribe(new AnonymousObserver<T>(onNext, ObservableSystem.GetUnhandledExceptionHandler(), Stubs.HandleResult));
+        return source.Subscribe(new AnonymousObserver<T>(onNext, (ex) => ObservableSystem.GetUnhandledExceptionHandler().Invoke(ex), Stubs.HandleResult));
     }
 
     [DebuggerStepThrough]
     public static IDisposable Subscribe<T>(this Observable<T> source, Action<T> onNext, Action<Result> onCompleted)
     {
-        return source.Subscribe(new AnonymousObserver<T>(onNext, ObservableSystem.GetUnhandledExceptionHandler(), onCompleted));
+        return source.Subscribe(new AnonymousObserver<T>(onNext, (ex) => ObservableSystem.GetUnhandledExceptionHandler().Invoke(ex), onCompleted));
     }
 
     [DebuggerStepThrough]

--- a/src/R3/Operators/SubscribeAwait.cs
+++ b/src/R3/Operators/SubscribeAwait.cs
@@ -8,13 +8,13 @@ public static partial class ObservableExtensions
     /// <param name="maxConcurrent">This option is only valid for AwaitOperation.Parallel and AwaitOperation.SequentialParallel. It sets the number of concurrent executions. If set to -1, there is no limit.</param>
     public static IDisposable SubscribeAwait<T>(this Observable<T> source, Func<T, CancellationToken, ValueTask> onNextAsync, AwaitOperation awaitOperation = AwaitOperation.Sequential, bool configureAwait = true, bool cancelOnCompleted = false, int maxConcurrent = -1)
     {
-        return SubscribeAwait(source, onNextAsync, ObservableSystem.GetUnhandledExceptionHandler(), Stubs.HandleResult, awaitOperation, configureAwait, cancelOnCompleted, maxConcurrent);
+        return SubscribeAwait(source, onNextAsync, (ex) => ObservableSystem.GetUnhandledExceptionHandler().Invoke(ex), Stubs.HandleResult, awaitOperation, configureAwait, cancelOnCompleted, maxConcurrent);
     }
 
     /// <param name="maxConcurrent">This option is only valid for AwaitOperation.Parallel and AwaitOperation.SequentialParallel. It sets the number of concurrent executions. If set to -1, there is no limit.</param>
     public static IDisposable SubscribeAwait<T>(this Observable<T> source, Func<T, CancellationToken, ValueTask> onNextAsync, Action<Result> onCompleted, AwaitOperation awaitOperation = AwaitOperation.Sequential, bool configureAwait = true, bool cancelOnCompleted = false, int maxConcurrent = -1)
     {
-        return SubscribeAwait(source, onNextAsync, ObservableSystem.GetUnhandledExceptionHandler(), onCompleted, awaitOperation, configureAwait, cancelOnCompleted, maxConcurrent);
+        return SubscribeAwait(source, onNextAsync, (ex) => ObservableSystem.GetUnhandledExceptionHandler().Invoke(ex), onCompleted, awaitOperation, configureAwait, cancelOnCompleted, maxConcurrent);
     }
 
     /// <param name="maxConcurrent">This option is only valid for AwaitOperation.Parallel and AwaitOperation.SequentialParallel. It sets the number of concurrent executions. If set to -1, there is no limit.</param>


### PR DESCRIPTION
- Fixes #328

## Previous behaviour
`Subscribe` and `SubscribeAwait` were embedding the exception handler at the moment of subscription.
This made it so that if a different handler was registered, the previous one was was still used at the moment of exception.

## New behaviour
Embed a lambda that gets the currently registered handler and invokes it at the moment of exception. 
This allows long running subscriptions to get their handlers updated correctly if they are changed.