### PR TITLE
Fix: AsObservable immediately calls Dispose on completion

### DIFF
--- a/src/R3/Operators/AsObservable.cs
+++ b/src/R3/Operators/AsObservable.cs
@@ -22,7 +22,32 @@ internal sealed class AsObservable<T>(Observable<T> observable) : Observable<T>
 {
     protected override IDisposable SubscribeCore(Observer<T> observer)
     {
-        return observable.Subscribe(observer.Wrap());
+        return observable.Subscribe(new AsObservableObserver(observer));
+    }
+
+    sealed class AsObservableObserver(Observer<T> observer) : Observer<T>
+    {
+        protected override bool AutoDisposeOnCompleted => false;
+
+        protected override void OnNextCore(T value)
+        {
+            observer.OnNext(value);
+        }
+
+        protected override void OnErrorResumeCore(Exception error)
+        {
+            observer.OnErrorResume(error);
+        }
+
+        protected override void OnCompletedCore(Result result)
+        {
+            observer.OnCompleted(result);
+        }
+
+        protected override void DisposeCore()
+        {
+            observer.Dispose();
+        }
     }
 }
 
@@ -35,6 +60,8 @@ internal sealed class AsSystemObservable<T>(Observable<T> source) : IObservable<
 
     sealed class ObserverToObserver(IObserver<T> observer) : Observer<T>
     {
+        protected override bool AutoDisposeOnCompleted => false;
+
         protected override void OnNextCore(T value)
         {
             observer.OnNext(value);

--- a/tests/R3.Tests/OperatorTests/AsObservableTest.cs
+++ b/tests/R3.Tests/OperatorTests/AsObservableTest.cs
@@ -18,9 +18,25 @@ public class AsObservableTest
     }
 
     [Fact]
+    public void AsObservableWithDelay()
+    {
+        var p = new Subject<int>();
+        var fakeFrameProvider = new FakeFrameProvider();
+
+        var l = p.AsObservable().DelayFrame(1, fakeFrameProvider).ToLiveList();
+        p.OnNext(1);
+        p.OnNext(2);
+        p.OnNext(3);
+        p.OnCompleted();
+        fakeFrameProvider.Advance();
+
+        l.AssertEqual([1, 2, 3]);
+        l.AssertIsCompleted();
+    }
+
+    [Fact]
     public void AsSystemObservable()
     {
-
         {
             var p = new Subject<int>();
             var l = new List<int>();


### PR DESCRIPTION
As pointed out in #330, when using `AsObservable()` in combination with message-delaying operators such as `Delay` or `ObserveOn`, the OnCompleted signal was not properly propagated downstream.

```cs
var subject = new Subject<Unit>();
var fakeFrameProvider = new FakeFrameProvider();

subject
    .AsObservable()
    .ObserveOn(fakeFrameProvider)
    .Subscribe(
        onNext: _ => Console.WriteLine("Next"),
        onCompleted: _ => Console.WriteLine("Completed")
    );

subject.OnNext(Unit.Default);
fakeFrameProvider.Advance();
subject.OnCompleted();
fakeFrameProvider.Advance();

// "Completed" is not printed
```

The cause was that `WrappedObserver` is defined with `AutoDisposeOnCompleted = true`, and `AsObservable()` uses it as-is.
As a fix, `AsObservable()` now uses a dedicated observer.

A similar issue was also present in `AsSystemObservable()`, so it has been fixed as well.