### PR TITLE
Unity: Retain subscriptions when EnteredEditMode is invoked

### DIFF
--- a/src/R3.Unity/Assets/R3.Unity/Runtime/PlayerLoopHelper.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/PlayerLoopHelper.cs
@@ -117,7 +117,7 @@ namespace R3
 #if UNITY_EDITOR
             EditorApplication.playModeStateChanged += (state) =>
             {
-                if (state == PlayModeStateChange.EnteredEditMode || state == PlayModeStateChange.ExitingEditMode)
+                if (state == PlayModeStateChange.ExitingPlayMode || state == PlayModeStateChange.ExitingEditMode)
                 {
                     // run rest action before clear.
                     if (runner != null)

--- a/src/R3.Unity/Assets/R3.Unity/Runtime/PlayerLoopHelper.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/PlayerLoopHelper.cs
@@ -117,7 +117,7 @@ namespace R3
 #if UNITY_EDITOR
             EditorApplication.playModeStateChanged += (state) =>
             {
-                if (state == PlayModeStateChange.EnteredEditMode || state == PlayModeStateChange.ExitingEditMode)
+                if (state == PlayModeStateChange.ExitingEditMode)
                 {
                     // run rest action before clear.
                     if (runner != null)

--- a/src/R3.Unity/Assets/R3.Unity/Runtime/PlayerLoopHelper.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Runtime/PlayerLoopHelper.cs
@@ -117,7 +117,7 @@ namespace R3
 #if UNITY_EDITOR
             EditorApplication.playModeStateChanged += (state) =>
             {
-                if (state == PlayModeStateChange.ExitingEditMode)
+                if (state == PlayModeStateChange.EnteredEditMode || state == PlayModeStateChange.ExitingEditMode)
                 {
                     // run rest action before clear.
                     if (runner != null)


### PR DESCRIPTION
**Summary**  
Subscriptions created in `OnEnable `or `Start` are cleared when Unity re-enters Edit Mode because `UnityFrameProvider.Clear()` is called during `PlayModeStateChange.EnteredEditModeand`.
As a result, setting up new subscriptions when Edit Mode is entered again becomes difficult.

**Observed order (Unity 6000.1.10f1, 2022.3.9f1)**  
```
ExitingPlayMode   ← Clear() [to-be]
OnEnable
Start
EnteredEditMode   ← Clear() [as-is]
```

**Minimal repro**

```csharp
using R3;
using UnityEditor;
using UnityEngine;

[ExecuteAlways]
public class R3Test : MonoBehaviour
{
    [InitializeOnLoadMethod]
    private static void Init()
    {
        EditorApplication.playModeStateChanged += state =>
        {
            Debug.Log($"Play mode state changed: {state}");
        };
    }

    private void Start()
    {
        Debug.Log(nameof(Start));
        Observable.EveryUpdate(UnityFrameProvider.PreLateUpdate, destroyCancellationToken)
                  .Take(5)
                  .Subscribe(_ => Debug.Log($"Subscribe in Start: {Time.frameCount}"));
    }

    private void OnEnable()
    {
        Debug.Log(nameof(OnEnable));
        Observable.EveryUpdate(UnityFrameProvider.PreLateUpdate, destroyCancellationToken)
                  .Take(5)
                  .Subscribe(_ => Debug.Log($"Subscribe in OnEnable: {Time.frameCount}"));
    }

    private void OnDestroy() => Debug.Log(nameof(OnDestroy));
}
```