### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,11 @@
 <Project>
 
   <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
+
     <!-- NuGet Packaging -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Company>Cysharp</Company>
     <Authors>Cysharp</Authors>
@@ -12,14 +16,12 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>Icon.png</PackageIcon>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../opensource.snk</AssemblyOriginatorKeyFile>
-    <!-- For BenchmarkDotNet generated project-->
-    <AssemblyOriginatorKeyFile Condition="EXISTS('./../../../../../../opensource.snk')">../../../../../../opensource.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
 
 </Project>

--- a/sandbox/AvaloniaApplication1/AvaloniaApplication1.csproj
+++ b/sandbox/AvaloniaApplication1/AvaloniaApplication1.csproj
@@ -6,9 +6,7 @@
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
-
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.0.6" />

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -5,7 +5,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sandbox/BlazorApp1/BlazorApp1.csproj
+++ b/sandbox/BlazorApp1/BlazorApp1.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sandbox/BlazorWebAssemblyApp1/BlazorWebAssemblyApp1.csproj
+++ b/sandbox/BlazorWebAssemblyApp1/BlazorWebAssemblyApp1.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sandbox/ConsoleApp1/ConsoleApp1.csproj
+++ b/sandbox/ConsoleApp1/ConsoleApp1.csproj
@@ -6,7 +6,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sandbox/MauiApp1/MauiApp1.csproj
+++ b/sandbox/MauiApp1/MauiApp1.csproj
@@ -20,7 +20,6 @@
         <SingleProject>true</SingleProject>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
 
         <!-- Display name -->
         <ApplicationTitle>MauiApp1</ApplicationTitle>

--- a/sandbox/MonoGameApplication1/MonoGameApplication1.csproj
+++ b/sandbox/MonoGameApplication1/MonoGameApplication1.csproj
@@ -5,7 +5,6 @@
         <RollForward>Major</RollForward>
         <PublishReadyToRun>false</PublishReadyToRun>
         <TieredCompilation>false</TieredCompilation>
-        <IsPackable>false</IsPackable>
         <NoWarn>CS8002</NoWarn>
     </PropertyGroup>
     <PropertyGroup>

--- a/sandbox/ReferenceBuilder/ReferenceBuilder.csproj
+++ b/sandbox/ReferenceBuilder/ReferenceBuilder.csproj
@@ -5,7 +5,6 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sandbox/WinFormsApp1/WinFormsApp1.csproj
+++ b/sandbox/WinFormsApp1/WinFormsApp1.csproj
@@ -7,7 +7,6 @@
         <UseWindowsForms>true</UseWindowsForms>
         <ImplicitUsings>enable</ImplicitUsings>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sandbox/WinUI3App1/WinUI3App1.csproj
+++ b/sandbox/WinUI3App1/WinUI3App1.csproj
@@ -11,7 +11,6 @@
         <UseWinUI>true</UseWinUI>
         <EnableMsixTooling>true</EnableMsixTooling>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>
@@ -30,7 +29,7 @@
         <Manifest Include="$(ApplicationManifest)" />
     </ItemGroup>
 
-    <!-- 
+    <!--
     Defining the "Msix" ProjectCapability here allows the Single-project MSIX Packaging
     Tools extension to be activated for this project even if the Windows App SDK Nuget
     package has not yet been restored.
@@ -42,9 +41,9 @@
         <ProjectReference Include="..\..\src\R3.WinUI3\R3.WinUI3.csproj" />
     </ItemGroup>
 
-    <!-- 
-    Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution 
-    Explorer "Package and Publish" context menu entry to be enabled for this project even if 
+    <!--
+    Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution
+    Explorer "Package and Publish" context menu entry to be enabled for this project even if
     the Windows App SDK Nuget package has not yet been restored.
   -->
     <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">

--- a/sandbox/WpfApp1/WpfApp1.csproj
+++ b/sandbox/WpfApp1/WpfApp1.csproj
@@ -7,7 +7,6 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <UseWPF>true</UseWPF>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
-        <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/R3.Avalonia/R3.Avalonia.csproj
+++ b/src/R3.Avalonia/R3.Avalonia.csproj
@@ -9,14 +9,11 @@
         <NoWarn>1701;1702;1591;1573</NoWarn>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.Avalonia</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>Avalonia Provider and Methods for R3.</Description>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.0.0" />

--- a/src/R3.Blazor/R3.Blazor.csproj
+++ b/src/R3.Blazor/R3.Blazor.csproj
@@ -11,14 +11,11 @@
         <RootNamespace>R3</RootNamespace>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.Blazor</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>Blazor Provider and Methods for R3.</Description>
-        <IsPackable>true</IsPackable>
     </PropertyGroup>
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\R3\R3.csproj" />

--- a/src/R3.BlazorWebAssembly/R3.BlazorWebAssembly.csproj
+++ b/src/R3.BlazorWebAssembly/R3.BlazorWebAssembly.csproj
@@ -11,14 +11,12 @@
         <RootNamespace>R3</RootNamespace>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.BlazorWebAssembly</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>BlazorWebAssembly Provider and Methods for R3.</Description>
-        <IsPackable>true</IsPackable>
     </PropertyGroup>
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
+
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     </ItemGroup>

--- a/src/R3.Godot/R3.Godot.csproj
+++ b/src/R3.Godot/R3.Godot.csproj
@@ -5,7 +5,8 @@
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <NoWarn>1701;1702;1591;1573;8002;</NoWarn>
-        <!-- Currently no packable -->
+
+        <!-- Currently not packable -->
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/R3.LogicLooper/R3.LogicLooper.csproj
+++ b/src/R3.LogicLooper/R3.LogicLooper.csproj
@@ -9,14 +9,12 @@
         <NoWarn>1701;1702;1591;1573</NoWarn>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.LogicLooper</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>LogicLooper Provider and Methods for R3.</Description>
     </PropertyGroup>
 
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
     <ItemGroup>
         <PackageReference Include="LogicLooper" Version="1.5.0" />
     </ItemGroup>

--- a/src/R3.Maui/R3.Maui.csproj
+++ b/src/R3.Maui/R3.Maui.csproj
@@ -9,14 +9,11 @@
         <NoWarn>1701;1702;1591;1573;CS8002</NoWarn>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.Maui</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>.NET MAUI Provider and Methods for R3.</Description>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Maui.Core" Version="8.0.3" />

--- a/src/R3.MonoGame/R3.MonoGame.csproj
+++ b/src/R3.MonoGame/R3.MonoGame.csproj
@@ -9,14 +9,11 @@
         <NoWarn>1701;1702;1591;1573;CS8002</NoWarn>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.MonoGame</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>MonoGame Provider and Methods for R3.</Description>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303">

--- a/src/R3.Stride/R3.Stride.csproj
+++ b/src/R3.Stride/R3.Stride.csproj
@@ -5,6 +5,7 @@
         <Nullable>enable</Nullable>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.Stride</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>Stride Provider and Methods for R3.</Description>
@@ -14,8 +15,5 @@
         <ProjectReference Include="../R3/R3.csproj" />
         <PackageReference Include="Stride.Engine" Version="4.2.0.2067" PrivateAssets="contentfiles;analyzers" />
         <PackageReference Include="Stride.UI" Version="4.2.0.2067" PrivateAssets="contentFiles;analyzers" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
     </ItemGroup>
 </Project>

--- a/src/R3.Uno/R3.Uno.csproj
+++ b/src/R3.Uno/R3.Uno.csproj
@@ -7,14 +7,11 @@
         <NoWarn>1701;1702;CS8002</NoWarn>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.Uno</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>Uno Provider and Methods for R3.</Description>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Uno.Extensions.Logging.WinUI" Version="5.2.7" />

--- a/src/R3.WPF/R3.WPF.csproj
+++ b/src/R3.WPF/R3.WPF.csproj
@@ -12,14 +12,11 @@
         <NoWarn>1701;1702;1591;1573</NoWarn>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.WPF</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>WPF Provider and Methods for R3.</Description>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\R3\R3.csproj" />

--- a/src/R3.WinForms/R3.WinForms.csproj
+++ b/src/R3.WinForms/R3.WinForms.csproj
@@ -9,14 +9,12 @@
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.WinForms</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>WinForms Provider and Methods for R3.</Description>
     </PropertyGroup>
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
-    
+
     <ItemGroup>
         <ProjectReference Include="..\R3\R3.csproj" />
     </ItemGroup>

--- a/src/R3.WinUI3/R3.WinUI3.csproj
+++ b/src/R3.WinUI3/R3.WinUI3.csproj
@@ -16,6 +16,7 @@
         <GenerateLibraryLayout>true</GenerateLibraryLayout>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageId>R3Extensions.WinUI3</PackageId>
         <PackageTags>rx</PackageTags>
         <Description>WinUI3 Provider and Methods for R3.</Description>
@@ -29,9 +30,6 @@
         <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.0" />
     </ItemGroup>
 
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\R3\R3.csproj" />
     </ItemGroup>

--- a/src/R3/R3.csproj
+++ b/src/R3/R3.csproj
@@ -11,14 +11,10 @@
         <NoWarn>1701;1702;1591;1573</NoWarn>
 
         <!-- NuGet Packaging -->
+        <IsPackable>true</IsPackable>
         <PackageTags>rx</PackageTags>
         <Description>The evolution of dotnet/reactive and UniRx.</Description>
     </PropertyGroup>
-
-    <ItemGroup>
-        <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-        <EmbeddedResource Include="..\..\LICENSE" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="PolySharp" Version="1.14.1">

--- a/tests/R3.Tests/R3.Tests.csproj
+++ b/tests/R3.Tests/R3.Tests.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsPackable>false</IsPackable>
         <!-- xUnit1051 is async test for CancellationToken warning -->
         <NoWarn>9113;xUnit1051</NoWarn>
         <!-- Microsoft.Testing.Platform Support -->


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
