### PR TITLE
Fix: Ensures unsubscribing for `ToAsyncEnumerable` when await-foreach has got out

### DIFF
--- a/src/R3/Operators/ToAsyncEnumerable.cs
+++ b/src/R3/Operators/ToAsyncEnumerable.cs
@@ -21,13 +21,16 @@ public static partial class ObservableExtensions
             }, disposable);
         }
 
-        return channel.Reader.ReadAllAsync(cancellationToken);
+        observer.readerEnumerable = channel.Reader.ReadAllAsync(cancellationToken);
+        return observer;
     }
 }
 
-sealed class ToAsyncEnumerable<T>(ChannelWriter<T> writer) : Observer<T>
+sealed class ToAsyncEnumerable<T>(ChannelWriter<T> writer) : Observer<T>, IAsyncEnumerable<T>
 {
     public CancellationTokenRegistration registration;
+
+    public IAsyncEnumerable<T> readerEnumerable = null!;
 
     protected override void OnNextCore(T value)
     {
@@ -54,6 +57,25 @@ sealed class ToAsyncEnumerable<T>(ChannelWriter<T> writer) : Observer<T>
     protected override void DisposeCore()
     {
         registration.Dispose();
+    }
+
+    public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+    {
+        return new AsyncEnumerator_(this, readerEnumerable.GetAsyncEnumerator(cancellationToken));
+    }
+
+    sealed class AsyncEnumerator_(ToAsyncEnumerable<T> owner, IAsyncEnumerator<T> enumerator) : IAsyncEnumerator<T>
+    {
+        public T Current => enumerator.Current;
+        public async ValueTask DisposeAsync()
+        {
+            await enumerator.DisposeAsync();
+            owner.Dispose();
+        }
+        public ValueTask<bool> MoveNextAsync()
+        {
+            return enumerator.MoveNextAsync();
+        }
     }
 }
 

--- a/tests/R3.Tests/OperatorTests/ToAsyncEnumerableTest.cs
+++ b/tests/R3.Tests/OperatorTests/ToAsyncEnumerableTest.cs
@@ -55,4 +55,34 @@ public class ToAsyncEnumerableTest
         l.ShouldBe([1, 10, 100]);
         disposed.ShouldBeTrue();
     }
+
+    [Fact]
+    async Task UnsubscribeWhenBreak()
+    {
+        var publisher = new Subject<int>();
+        var cts = new CancellationTokenSource();
+
+        var disposed = false;
+        var e = publisher.Do(onDispose: () => disposed = true).ToAsyncEnumerable(cts.Token);
+
+        publisher.OnNext(1);
+        publisher.OnNext(10);
+
+        publisher.OnNext(100);
+        // publisher.OnCompleted();
+
+        var l = new List<int>();
+
+        await foreach (var item in e)
+        {
+            l.Add(item);
+            if (item == 10)
+            {
+                break;
+            }
+        }
+
+        l.ShouldBe([1, 10]);
+        disposed.ShouldBeTrue();
+    }
 }


### PR DESCRIPTION
This PR fixes #361.

### modifications

- The return object from `ObservableExtensions.ToAsyncEnumerable<T>` is wrapped, and its iterator calles `Dispose` of subscription from its `DisposeAsync`.
- A new test for `ToAsyncEnumerable<T>` is added.

### breaking change

- No API signature breaking change is introduced.
- Now the subscription is reliably unsubscribed when escaping the await-foreach.
  This is likely to be preferable to the previous behavior, but may change side effects in end-user code.