### PR TITLE
Godot - Fix Observable Tracker stability & Enhance UX (Hide Ops, Simple Trace, Jump to Source)

### DIFF
--- a/src/R3.Godot/addons/R3.Godot/GodotR3Plugin.cs
+++ b/src/R3.Godot/addons/R3.Godot/GodotR3Plugin.cs
@@ -1,6 +1,7 @@
 ﻿#if TOOLS
 #nullable enable
 
+using System;
 using Godot;
 
 namespace R3;
@@ -8,25 +9,97 @@ namespace R3;
 [Tool]
 public partial class GodotR3Plugin : EditorPlugin
 {
-    static ObservableTrackerDebuggerPlugin? observableTrackerDebugger;
+    // Static reference to detect Hot Reload state
+
+    // Cooldown to prevent spamming init on failure
+    private int _initCooldown;
+
+    // Public accessor for Tabs to find the active plugin instance
+    public static ObservableTrackerDebuggerPlugin? CurrentDebuggerPlugin { get; private set; }
+
     public override void _EnterTree()
     {
-        observableTrackerDebugger ??= new ObservableTrackerDebuggerPlugin();
-        AddDebuggerPlugin(observableTrackerDebugger);
-        // Automatically install autoloads here for ease of use.
-        AddAutoloadSingleton(nameof(FrameProviderDispatcher), "res://addons/R3.Godot/FrameProviderDispatcher.cs");
-        AddAutoloadSingleton(nameof(ObservableTrackerRuntimeHook), "res://addons/R3.Godot/ObservableTrackerRuntimeHook.cs");
+        InitializeDebuggerPlugin();
     }
 
     public override void _ExitTree()
     {
-        if (observableTrackerDebugger != null)
+        // Only remove the debugger plugin registration.
+        // Do not nullify the static reference here to allow Hot Reload to take over.
+        if (CurrentDebuggerPlugin != null)
+            RemoveDebuggerPlugin(CurrentDebuggerPlugin);
+    }
+
+    public override void _DisablePlugin()
+    {
+        // Full cleanup when the user explicitly disables the plugin
+        if (CurrentDebuggerPlugin != null)
         {
-            RemoveDebuggerPlugin(observableTrackerDebugger);
-            observableTrackerDebugger = null;
+            CurrentDebuggerPlugin.Shutdown();
+            RemoveDebuggerPlugin(CurrentDebuggerPlugin);
+            CurrentDebuggerPlugin = null;
         }
+
         RemoveAutoloadSingleton(nameof(FrameProviderDispatcher));
         RemoveAutoloadSingleton(nameof(ObservableTrackerRuntimeHook));
+    }
+
+    public override void _Process(double delta)
+    {
+        if (_initCooldown > 0)
+        {
+            _initCooldown--;
+            return;
+        }
+
+        // Heartbeat check: If static reference is null, Hot Reload occurred.
+        if (CurrentDebuggerPlugin == null)
+            InitializeDebuggerPlugin();
+    }
+
+    private void InitializeDebuggerPlugin()
+    {
+        if (CurrentDebuggerPlugin != null)
+            return;
+
+        try
+        {
+            // 1. Instantiate (State: Uninitialized)
+            CurrentDebuggerPlugin = new ObservableTrackerDebuggerPlugin();
+
+            // 2. Explicit Initialize (State: Active)
+            CurrentDebuggerPlugin.Initialize();
+
+            // 3. Register to Editor
+            AddDebuggerPlugin(CurrentDebuggerPlugin);
+
+            // 4. Resurrect existing UI Tabs
+            var baseControl = EditorInterface.Singleton.GetBaseControl();
+            if (baseControl != null)
+                // CallDeferred to ensure the Editor UI tree is stable
+                Callable.From(() =>
+                {
+                    if (CurrentDebuggerPlugin != null)
+                        CurrentDebuggerPlugin.ResurrectExistingTabs(baseControl.GetTree());
+                }).CallDeferred();
+
+            // 5. Register Runtime Autoloads
+            AddAutoloadSafe(nameof(FrameProviderDispatcher), "res://addons/R3.Godot/FrameProviderDispatcher.cs");
+            AddAutoloadSafe(nameof(ObservableTrackerRuntimeHook),
+                "res://addons/R3.Godot/ObservableTrackerRuntimeHook.cs");
+        }
+        catch (Exception e)
+        {
+            GD.PrintErr($"[R3] Init failed: {e.Message}");
+            CurrentDebuggerPlugin = null;
+            _initCooldown = 120;
+        }
+    }
+
+    private void AddAutoloadSafe(string name, string path)
+    {
+        if (!ProjectSettings.HasSetting("autoload/" + name))
+            AddAutoloadSingleton(name, path);
     }
 }
 #endif

--- a/src/R3.Godot/addons/R3.Godot/ObservableTrackerDebuggerPlugin.cs
+++ b/src/R3.Godot/addons/R3.Godot/ObservableTrackerDebuggerPlugin.cs
@@ -1,150 +1,250 @@
 ﻿#if TOOLS
 #nullable enable
 
-using Godot;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Godot;
 using GDArray = Godot.Collections.Array;
 
 namespace R3;
 
-// ObservableTrackerDebuggerPlugin creates the Observable Tracker tab in the debugger, and communicates with ObservableTrackerRuntimeHook via EditorDebuggerSessions.
 [Tool]
 public partial class ObservableTrackerDebuggerPlugin : EditorDebuggerPlugin
 {
-    // Shared header used in IPC by ObservableTracker classes.
     public const string MessageHeader = "ObservableTracker";
-
-    // Implemented by ObservableTrackerRuntimeHook.
     public const string Message_RequestActiveTasks = "RequestActiveTasks";
     public const string Message_SetEnableStates = "SetEnableStates";
     public const string Message_InvokeGCCollect = "InvokeGCCollect";
-
-    // Implemented by ObservableTrackerDebuggerPlugin.
     public const string Message_ReceiveActiveTasks = "ReceiveActiveTasks";
 
-    // A TrackerSession isolates each debugger session's states.
-    // There's no way to know if a session has been disposed for good, so we will never remove anything from this dictionary.
-    // This is similar to how it is handled in the Godot core (see: https://github.com/godotengine/godot/blob/master/modules/multiplayer/editor/multiplayer_editor_plugin.cpp)
-    readonly Dictionary<int, TrackerSession> sessions = new();
+    public const string AllTabsGroup = "R3_Tracker_Tabs_All";
 
-    private class TrackerSession
+    // Static field to hold the ONLY valid instance (Highlander Principle)
+    // Used to silence ghost instances after Hot Reload.
+    private static ObservableTrackerDebuggerPlugin? _currentActiveInstance;
+
+    private readonly Dictionary<int, ObservableTrackerSession> sessions = new();
+
+    // Empty constructor to avoid side effects during Godot's internal instantiation
+
+    public bool IsInitialized { get; private set; }
+
+    // Explicit initialization called by GodotR3Plugin
+    public void Initialize()
     {
-        public readonly EditorDebuggerSession debuggerSession;
-        public readonly List<TrackingState> states = new();
-        public event Action<IEnumerable<TrackingState>>? ReceivedActiveTasks;
+        if (IsInitialized)
+            return;
+        IsInitialized = true;
 
-        public TrackerSession(EditorDebuggerSession debuggerSession)
-        {
-            this.debuggerSession = debuggerSession;
-        }
+        // Claim authority
+        _currentActiveInstance = this;
+    }
 
-        public void InvokeReceivedActiveTasks()
+    public void Shutdown()
+    {
+        IsInitialized = false;
+        sessions.Clear();
+
+        if (_currentActiveInstance == this)
+            _currentActiveInstance = null;
+    }
+
+    // Checks if this instance is the current valid one
+    private bool IsActiveInstance()
+    {
+        return IsInitialized && _currentActiveInstance == this;
+    }
+
+    private void CleanUpStaleSessions()
+    {
+        const int MaxSessions = 5;
+
+        if (sessions.Count > MaxSessions)
         {
-            ReceivedActiveTasks?.Invoke(states);
+            var sessionsToRemove = sessions.Keys.OrderBy(id => id).Take(sessions.Count - MaxSessions).ToList();
+            foreach (var id in sessionsToRemove)
+                sessions.Remove(id);
         }
     }
 
     public override void _SetupSession(int sessionId)
     {
+        if (!IsActiveInstance())
+            return;
+
+        CleanUpStaleSessions();
+
         var currentSession = GetSession(sessionId);
-        sessions[sessionId] = new TrackerSession(currentSession);
+        if (currentSession == null)
+            return;
 
-        // NotifyOnSessionSetup gives the tab a reference to the debugger plugin, as well as the sessionId which is needed for messages.
-		var tab = new ObservableTrackerTab();
+        var trackerSession = new ObservableTrackerSession();
+        sessions[sessionId] = trackerSession;
+
+        // UI Handling
+        ObservableTrackerTab tab;
+        var isReusingTab = false;
+
+        var tree = EditorInterface.Singleton.GetBaseControl().GetTree();
+        var sessionGroup = $"R3_Tracker_UI_Session_{sessionId}";
+        var existingNodes = tree.GetNodesInGroup(sessionGroup);
+
+        if (existingNodes.Count > 0 && existingNodes[0] is ObservableTrackerTab oldTab)
+        {
+            tab = oldTab;
+            isReusingTab = true;
+        }
+        else
+        {
+            tab = new ObservableTrackerTab();
+            tab.AddToGroup(sessionGroup);
+            tab.AddToGroup(AllTabsGroup);
+        }
+
         tab.NotifyOnSessionSetup(this, sessionId);
-        currentSession.AddSessionTab(tab);
 
-        // As sessions don't seem to be ever disposed, we don't need to unregister these callbacks either.
-        currentSession.Started += () =>
-        {
-            if (IsInstanceValid(tab))
-            {
-                tab.SetProcess(true);
-                // Important! We need to tell the tab the session has started, so it can initialize the enabled states of the runtime ObservableTracker.
-                tab.NotifyOnSessionStart();
-            }
-        };
-        currentSession.Stopped += () =>
-        {
-            if (IsInstanceValid(tab))
-            {
-                tab.SetProcess(false);
-            }
-        };
+        if (!isReusingTab)
+            currentSession.AddSessionTab(tab);
+
+        trackerSession.Initialize(currentSession, tab);
+
+        if (!currentSession.IsConnected("started",
+                new Callable(trackerSession, ObservableTrackerSession.MethodName.OnSessionStarted)))
+            currentSession.Connect("started",
+                new Callable(trackerSession, ObservableTrackerSession.MethodName.OnSessionStarted));
+
+        if (!currentSession.IsConnected("stopped",
+                new Callable(trackerSession, ObservableTrackerSession.MethodName.OnSessionStopped)))
+            currentSession.Connect("stopped",
+                new Callable(trackerSession, ObservableTrackerSession.MethodName.OnSessionStopped));
+
+        if (currentSession.IsActive())
+            trackerSession.OnSessionStarted();
     }
 
     public override bool _HasCapture(string capture)
     {
+        if (!IsActiveInstance())
+            return false;
         return capture == MessageHeader;
     }
 
     public override bool _Capture(string message, GDArray data, int sessionId)
     {
-        // When EditorDebuggerPlugin._Capture receives messages, the header isn't trimmed (unlike how it is in EngineDebugger),
-        // so we need to trim it here.
-        string messageWithoutHeader = message.Substring(message.IndexOf(':') + 1);
-        //GD.Print(nameof(ObservableTrackerDebuggerPlugin) + " received " + messageWithoutHeader);
-        switch(messageWithoutHeader)
-        {
-            case Message_ReceiveActiveTasks:
-                // Only invoke event if updated.
-                if (data[0].AsBool())
+        // Block ghost instances to prevent duplicate logs
+        if (!IsActiveInstance())
+            return false;
+
+        if (!message.StartsWith(MessageHeader + ":"))
+            return base._Capture(message, data, sessionId);
+
+        var messageWithoutHeader = message.Substring(message.IndexOf(':') + 1);
+
+        if (!sessions.ContainsKey(sessionId))
+            _SetupSession(sessionId);
+
+        if (sessions.TryGetValue(sessionId, out var session))
+            try
+            {
+                switch (messageWithoutHeader)
                 {
-                    var session = sessions[sessionId];
-                    session.states.Clear();
-                    foreach (GDArray item in data[1].AsGodotArray())
-                    {
-                        var state = new TrackingState()
-                        {
-                            TrackingId = item[0].AsInt32(),
-                            FormattedType = item[1].AsString(),
-                            AddTime = new DateTime(item[2].AsInt64()),
-                            StackTrace = item[3].AsString(),
-                        };;
-                        session.states.Add(state);
-                    }
-                    session.InvokeReceivedActiveTasks();
+                    case Message_ReceiveActiveTasks:
+                        if (data.Count > 0 && data[0].VariantType == Variant.Type.Bool && data[0].AsBool())
+                            if (data.Count > 1)
+                            {
+                                var tasks = data[1].AsGodotArray();
+                                session.States.Clear();
+                                foreach (GDArray item in tasks)
+                                    session.States.Add(new TrackingState
+                                    {
+                                        TrackingId = item[0].AsInt32(),
+                                        FormattedType = item[1].AsString(),
+                                        // Use DateTimeKind.Local as R3 sends local ticks
+                                        AddTime = new DateTime(item[2].AsInt64(), DateTimeKind.Local),
+                                        StackTrace = item[3].AsString()
+                                    });
+                                session.InvokeReceivedActiveTasks();
+                            }
+
+                        break;
                 }
-                return true;
-        }
-        return base._Capture(message, data, sessionId);
+            }
+            catch (Exception e)
+            {
+                GD.PushWarning($"[R3 Plugin] Parse error: {e.Message}");
+            }
+
+        return true;
+    }
+
+    public void ResurrectExistingTabs(SceneTree tree)
+    {
+        if (!IsActiveInstance())
+            return;
+
+        var existingTabs = tree.GetNodesInGroup(AllTabsGroup);
+        foreach (var node in existingTabs)
+            if (node is ObservableTrackerTab tab)
+            {
+                var sessionId = tab.SessionId;
+                if (sessionId == -1)
+                    continue;
+
+                var currentSession = GetSession(sessionId);
+                if (currentSession == null)
+                    continue;
+
+                var trackerSession = new ObservableTrackerSession();
+                sessions[sessionId] = trackerSession;
+
+                tab.NotifyOnSessionSetup(this, sessionId);
+                trackerSession.Initialize(currentSession, tab);
+
+                if (!currentSession.IsConnected("started",
+                        new Callable(trackerSession, ObservableTrackerSession.MethodName.OnSessionStarted)))
+                    currentSession.Connect("started",
+                        new Callable(trackerSession, ObservableTrackerSession.MethodName.OnSessionStarted));
+                if (!currentSession.IsConnected("stopped",
+                        new Callable(trackerSession, ObservableTrackerSession.MethodName.OnSessionStopped)))
+                    currentSession.Connect("stopped",
+                        new Callable(trackerSession, ObservableTrackerSession.MethodName.OnSessionStopped));
+
+                if (currentSession.IsActive())
+                    trackerSession.OnSessionStarted();
+            }
     }
 
     public void RegisterReceivedActiveTasks(int sessionId, Action<IEnumerable<TrackingState>> action)
     {
-        if (sessions.Count > 0)
-            sessions[sessionId].ReceivedActiveTasks += action;
+        if (IsActiveInstance())
+            sessions.GetValueOrDefault(sessionId)?.RegisterReceivedActiveTasks(action);
     }
 
     public void UnregisterReceivedActiveTasks(int sessionId, Action<IEnumerable<TrackingState>> action)
     {
-        if (sessions.Count > 0)
-            sessions[sessionId].ReceivedActiveTasks -= action;
+        if (IsActiveInstance())
+            sessions.GetValueOrDefault(sessionId)?.UnregisterReceivedActiveTasks(action);
     }
 
     public void UpdateTrackingStates(int sessionId, bool forceUpdate = false)
     {
-        if (sessions.Count > 0 && sessions[sessionId].debuggerSession.IsActive())
-        {
-            sessions[sessionId].debuggerSession.SendMessage(MessageHeader + ":" + Message_RequestActiveTasks, new () { forceUpdate });
-        }
+        if (IsActiveInstance())
+            sessions.GetValueOrDefault(sessionId)
+                ?.RequestUpdate(MessageHeader, Message_RequestActiveTasks, forceUpdate);
     }
 
     public void SetEnableStates(int sessionId, bool enableTracking, bool enableStackTrace)
     {
-        if (sessions.Count > 0 && sessions[sessionId].debuggerSession.IsActive())
-        {
-            sessions[sessionId].debuggerSession.SendMessage(MessageHeader + ":" + Message_SetEnableStates, new () { enableTracking, enableStackTrace});
-        }
+        if (IsActiveInstance())
+            sessions.GetValueOrDefault(sessionId)
+                ?.SetStates(MessageHeader, Message_SetEnableStates, enableTracking, enableStackTrace);
     }
 
     public void InvokeGCCollect(int sessionId)
     {
-        if (sessions.Count > 0 && sessions[sessionId].debuggerSession.IsActive())
-        {
-            sessions[sessionId].debuggerSession.SendMessage(MessageHeader + ":" + Message_InvokeGCCollect);
-        }
+        if (IsActiveInstance())
+            sessions.GetValueOrDefault(sessionId)?.TriggerGC(MessageHeader, Message_InvokeGCCollect);
     }
 }
 #endif

--- a/src/R3.Godot/addons/R3.Godot/ObservableTrackerRuntimeHook.cs
+++ b/src/R3.Godot/addons/R3.Godot/ObservableTrackerRuntimeHook.cs
@@ -1,58 +1,74 @@
-﻿
+﻿#if TOOLS
 #nullable enable
 
-using Godot;
 using System;
+using Godot;
 using GDArray = Godot.Collections.Array;
 
 namespace R3;
 
-// Sends runtime ObservableTracker information to ObservableTrackerDebuggerPlugin.
-// Needs to be an Autoload. Should not be instantiated manually.
 public partial class ObservableTrackerRuntimeHook : Node
 {
     public override void _Ready()
     {
-#if TOOLS
-        EngineDebugger.RegisterMessageCapture(ObservableTrackerDebuggerPlugin.MessageHeader, Callable.From((string message, GDArray data) =>
-        { 
-            //GD.Print(nameof(ObservableTrackerRuntimeHook) + " received " + message);
-            switch (message)
+        // Enable tracking by default immediately on start.
+        ObservableTracker.EnableTracking = true;
+        ObservableTracker.EnableStackTrace = true;
+
+        EngineDebugger.RegisterMessageCapture(ObservableTrackerDebuggerPlugin.MessageHeader,
+            Callable.From((string message, GDArray data) =>
             {
-                case ObservableTrackerDebuggerPlugin.Message_RequestActiveTasks:
-                    // data[0]: If true, force an update anyway.
-                    if (ObservableTracker.CheckAndResetDirty() || data[0].AsBool())
-                    {
-                        GDArray states = new();
-                        ObservableTracker.ForEachActiveTask(state =>
+                var command = message.Contains(':') ? message.Substring(message.IndexOf(':') + 1) : message;
+
+                switch (command)
+                {
+                    case ObservableTrackerDebuggerPlugin.Message_RequestActiveTasks:
+                        if (ObservableTracker.CheckAndResetDirty() || (data.Count > 0 && data[0].AsBool()))
                         {
-                            // DateTime is not a Variant type, so we serialize it using Ticks instead.
-                            states.Add(new GDArray { state.TrackingId, state.FormattedType, state.AddTime.Ticks, state.StackTrace });
-                        });
-                        EngineDebugger.SendMessage(ObservableTrackerDebuggerPlugin.MessageHeader + ":" + ObservableTrackerDebuggerPlugin.Message_ReceiveActiveTasks, new () { true, states });
-                    }
-                    else
-                    {
-                        EngineDebugger.SendMessage(ObservableTrackerDebuggerPlugin.MessageHeader + ":" + ObservableTrackerDebuggerPlugin.Message_ReceiveActiveTasks, new () { false, });
-                    }
-                    break;
-                case ObservableTrackerDebuggerPlugin.Message_SetEnableStates:
-                    ObservableTracker.EnableTracking = data[0].AsBool();
-                    ObservableTracker.EnableStackTrace = data[1].AsBool();
-                    break;
-                case ObservableTrackerDebuggerPlugin.Message_InvokeGCCollect:
-                    GC.Collect(0);
-                    break;
-            }
-            return true;
-        }));
-#endif
+                            GDArray states = new();
+                            ObservableTracker.ForEachActiveTask(state =>
+                            {
+                                states.Add(new GDArray
+                                {
+                                    state.TrackingId, state.FormattedType, state.AddTime.Ticks, state.StackTrace
+                                });
+                            });
+
+                            EngineDebugger.SendMessage(
+                                ObservableTrackerDebuggerPlugin.MessageHeader + ":" +
+                                ObservableTrackerDebuggerPlugin.Message_ReceiveActiveTasks,
+                                new GDArray { true, states });
+                        }
+                        else
+                        {
+                            EngineDebugger.SendMessage(
+                                ObservableTrackerDebuggerPlugin.MessageHeader + ":" +
+                                ObservableTrackerDebuggerPlugin.Message_ReceiveActiveTasks, new GDArray { false });
+                        }
+
+                        break;
+
+                    case ObservableTrackerDebuggerPlugin.Message_SetEnableStates:
+                        if (data.Count >= 2)
+                        {
+                            ObservableTracker.EnableTracking = data[0].AsBool();
+                            ObservableTracker.EnableStackTrace = data[1].AsBool();
+                        }
+
+                        break;
+
+                    case ObservableTrackerDebuggerPlugin.Message_InvokeGCCollect:
+                        GC.Collect(0);
+                        break;
+                }
+
+                return true;
+            }));
     }
 
     public override void _ExitTree()
     {
-#if TOOLS
         EngineDebugger.UnregisterMessageCapture(ObservableTrackerDebuggerPlugin.MessageHeader);
-#endif
     }
 }
+#endif

--- a/src/R3.Godot/addons/R3.Godot/ObservableTrackerSession.cs
+++ b/src/R3.Godot/addons/R3.Godot/ObservableTrackerSession.cs
@@ -1,0 +1,84 @@
+﻿#if TOOLS
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Godot;
+using GDArray = Godot.Collections.Array;
+
+namespace R3;
+
+[Tool]
+public partial class ObservableTrackerSession : RefCounted
+{
+    public readonly List<TrackingState> States = new();
+
+    // Use WeakReference to prevent memory leaks
+    private WeakReference<EditorDebuggerSession>? _debuggerSessionRef;
+    private WeakReference<ObservableTrackerTab>? _tabRef;
+
+    public void Initialize(EditorDebuggerSession debuggerSession, ObservableTrackerTab tab)
+    {
+        _debuggerSessionRef = new WeakReference<EditorDebuggerSession>(debuggerSession);
+        _tabRef = new WeakReference<ObservableTrackerTab>(tab);
+    }
+
+    private EditorDebuggerSession? GetSession()
+    {
+        return _debuggerSessionRef != null && _debuggerSessionRef.TryGetTarget(out var s) ? s : null;
+    }
+
+    private ObservableTrackerTab? GetTab()
+    {
+        return _tabRef != null && _tabRef.TryGetTarget(out var t) && IsInstanceValid(t) ? t : null;
+    }
+
+    public void RequestUpdate(string header, string subMsg, bool forceUpdate)
+    {
+        var s = GetSession();
+        if (s != null && s.IsActive())
+            s.SendMessage(header + ":" + subMsg, new GDArray { forceUpdate });
+    }
+
+    public void SetStates(string header, string subMsg, bool enableTracking, bool enableStackTrace)
+    {
+        var s = GetSession();
+        if (s != null && s.IsActive())
+            s.SendMessage(header + ":" + subMsg, new GDArray { enableTracking, enableStackTrace });
+    }
+
+    public void TriggerGC(string header, string subMsg)
+    {
+        var s = GetSession();
+        if (s != null && s.IsActive())
+            s.SendMessage(header + ":" + subMsg);
+    }
+
+    public void OnSessionStarted()
+    {
+        GetTab()?.NotifyOnSessionStart();
+    }
+
+    public void OnSessionStopped()
+    {
+        GetTab()?.NotifyOnSessionStop();
+    }
+
+    public event Action<IEnumerable<TrackingState>>? ReceivedActiveTasks;
+
+    public void RegisterReceivedActiveTasks(Action<IEnumerable<TrackingState>> action)
+    {
+        ReceivedActiveTasks += action;
+    }
+
+    public void UnregisterReceivedActiveTasks(Action<IEnumerable<TrackingState>> action)
+    {
+        ReceivedActiveTasks -= action;
+    }
+
+    public void InvokeReceivedActiveTasks()
+    {
+        ReceivedActiveTasks?.Invoke(States);
+    }
+}
+#endif

--- a/src/R3.Godot/addons/R3.Godot/ObservableTrackerTab.cs
+++ b/src/R3.Godot/addons/R3.Godot/ObservableTrackerTab.cs
@@ -2,7 +2,6 @@
 #nullable enable
 
 using Godot;
-using System;
 
 namespace R3;
 
@@ -12,135 +11,221 @@ public partial class ObservableTrackerTab : VBoxContainer
     public const string EnableAutoReloadKey = "ObservableTracker_EnableAutoReloadKey";
     public const string EnableTrackingKey = "ObservableTracker_EnableTrackingKey";
     public const string EnableStackTraceKey = "ObservableTracker_EnableStackTraceKey";
-    bool enableAutoReload, enableTracking, enableStackTrace;
-    ObservableTrackerTree? tree;
-    ObservableTrackerDebuggerPlugin? debuggerPlugin;
-    int interval = 0;
-    int sessionId = 0;
+    public const string HideOperatorsKey = "ObservableTracker_HideOperatorsKey";
+    public const string SimpleTraceKey = "ObservableTracker_SimpleTraceKey";
+    private const double RefreshInterval = 2.0;
 
-    public void NotifyOnSessionSetup(ObservableTrackerDebuggerPlugin debuggerPlugin, int sessionId)
-    {
-        this.debuggerPlugin = debuggerPlugin;
-        this.sessionId = sessionId;
-        tree ??= new ObservableTrackerTree();
-        tree.NotifyOnSessionSetup(debuggerPlugin!, sessionId);
-    }
+    private ObservableTrackerDebuggerPlugin? _debuggerPlugin;
 
-    public void NotifyOnSessionStart()
+    private bool _enableAutoReload;
+    private bool _enableStackTrace;
+    private bool _enableTracking;
+    private bool _hideOperators;
+
+    private double _refreshTimer;
+    private bool _simpleTrace;
+    private ObservableTrackerTree? _tree;
+
+    // Persist SessionId via Metadata
+    public int SessionId
     {
-        debuggerPlugin!.SetEnableStates(sessionId, enableTracking, enableStackTrace);
+        get
+        {
+            if (HasMeta("R3_SessionId"))
+                return (int)GetMeta("R3_SessionId");
+            return -1;
+        }
+        private set => SetMeta("R3_SessionId", value);
     }
 
     public override void _Ready()
     {
+        if (!Engine.IsEditorHint())
+            return;
+
         Name = "Observable Tracker";
+        SetProcess(false);
 
-        tree ??= new ObservableTrackerTree();
-        
-        // Head panel
-        var headPanelLayout = new HBoxContainer();
-        headPanelLayout.SetAnchor(Side.Left, 0);
-        headPanelLayout.SetAnchor(Side.Right, 0);
-        AddChild(headPanelLayout);
+        // Active Reconnection Logic
+        var plugin = GodotR3Plugin.CurrentDebuggerPlugin;
 
-        // Toggle buttons (top left)
-        var enableAutoReloadToggle = new CheckButton
-        {
-            Text = "Enable AutoReload",
-            TooltipText = "Reload automatically."
-        };
-        var enableTrackingToggle = new CheckButton
-        {
-            Text = "Enable Tracking",
-            TooltipText = "Start to track Observable subscription. Performance impact: low"
-        };
-        var enableStackTraceToggle = new CheckButton
-        {
-            Text = "Enable StackTrace",
-            TooltipText = "Capture StackTrace when subscribed. Performance impact: high"
-        };
+        if (SessionId != -1 && plugin != null)
+            // Hot Reload detected: Reconnect immediately
+            NotifyOnSessionSetup(plugin, SessionId);
+        else
+            // New Instance
+            InitializeUI(false);
+    }
 
-        // For every button: Initialize pressed state and subscribe to Toggled event.
-        EditorSettings settings = EditorInterface.Singleton.GetEditorSettings();
-        enableAutoReloadToggle.ButtonPressed = enableAutoReload = GetSettingOrDefault(settings, EnableAutoReloadKey, false).AsBool();
-        enableAutoReloadToggle.Toggled += toggledOn =>
-        {
-            settings.SetSetting(EnableAutoReloadKey, toggledOn);
-            enableAutoReload = toggledOn;
-        };
-        enableTrackingToggle.ButtonPressed = enableTracking = GetSettingOrDefault(settings, EnableTrackingKey, false).AsBool();
-        enableTrackingToggle.Toggled += toggledOn =>
-        {
-            settings.SetSetting(EnableTrackingKey, toggledOn);
-            enableTracking = toggledOn;
-            debuggerPlugin!.SetEnableStates(sessionId, enableTracking, enableStackTrace);
-        };
-        enableStackTraceToggle.ButtonPressed = enableStackTrace = GetSettingOrDefault(settings, EnableStackTraceKey, false).AsBool();
-        enableStackTraceToggle.Toggled += toggledOn =>
-        {
-            settings.SetSetting(EnableStackTraceKey, toggledOn);
-            enableStackTrace = toggledOn;
-            debuggerPlugin!.SetEnableStates(sessionId, enableTracking, enableStackTrace);
-        };
+    public void NotifyOnSessionSetup(ObservableTrackerDebuggerPlugin debuggerPlugin, int sessionId)
+    {
+        _debuggerPlugin = debuggerPlugin;
+        SessionId = sessionId;
 
-        // Regular buttons (top right)
-        var reloadButton = new Button
-        {
-            Text = "Reload",
-            TooltipText = "Reload View."
-        };
-        var GCButton = new Button
-        {
-            Text = "GC.Collect",
-            TooltipText = "Invoke GC.Collect."
-        };
+        if (!IsInGroup(ObservableTrackerDebuggerPlugin.AllTabsGroup))
+            AddToGroup(ObservableTrackerDebuggerPlugin.AllTabsGroup);
 
-        reloadButton.Pressed += () =>
-        {
-            debuggerPlugin!.UpdateTrackingStates(sessionId, true);
-        };
-        GCButton.Pressed += () =>
-        {
-            debuggerPlugin!.InvokeGCCollect(sessionId);
-        };
+        var sessionGroup = $"R3_Tracker_UI_Session_{sessionId}";
+        if (!IsInGroup(sessionGroup))
+            AddToGroup(sessionGroup);
 
-        // Button layout.
-        headPanelLayout.AddChild(enableAutoReloadToggle);
-        headPanelLayout.AddChild(enableTrackingToggle);
-        headPanelLayout.AddChild(enableStackTraceToggle);
-        // Kind of like Unity's FlexibleSpace. Pushes the first three buttons to the left, and the remaining buttons to the right.
-        headPanelLayout.AddChild(new Control()
-        {
-            SizeFlagsHorizontal = SizeFlags.Expand,
-        });
-        headPanelLayout.AddChild(reloadButton);
-        headPanelLayout.AddChild(GCButton);
+        // Force rebuild UI to fix event bindings after hot reload
+        InitializeUI(true);
 
-        // Tree goes last.
-        AddChild(tree);
+        if (_tree != null)
+        {
+            _tree.NotifyOnSessionSetup(debuggerPlugin, sessionId);
+            _tree.SetHideOperators(_hideOperators);
+            _tree.SetSimpleTrace(_simpleTrace);
+        }
+
+        NotifyOnSessionStart();
+    }
+
+    public void NotifyOnSessionStart()
+    {
+        SetProcess(true);
+        if (_debuggerPlugin == null)
+            return;
+
+        _debuggerPlugin.SetEnableStates(SessionId, _enableTracking, _enableStackTrace);
+        _debuggerPlugin.UpdateTrackingStates(SessionId, true);
+    }
+
+    public void NotifyOnSessionStop()
+    {
+        SetProcess(false);
+        if (IsInstanceValid(_tree))
+            _tree!.ClearContent();
     }
 
     public override void _Process(double delta)
     {
-        if (enableAutoReload)
+        // Use delta accumulation for consistent timing
+        if (_enableAutoReload && _debuggerPlugin != null && SessionId != -1)
         {
-            if (interval++ % 120 == 0)
+            _refreshTimer += delta;
+            if (_refreshTimer >= RefreshInterval)
             {
-                debuggerPlugin!.UpdateTrackingStates(sessionId);
+                _refreshTimer = 0;
+                _debuggerPlugin.UpdateTrackingStates(SessionId);
             }
         }
     }
 
-    static Variant GetSettingOrDefault(EditorSettings settings, string key, Variant @default)
+    private void InitializeUI(bool forceRebuild)
     {
-        if (settings.HasSetting(key))
+        // 1. Cleanup existing nodes if forcing rebuild
+        if (forceRebuild)
         {
-            return settings.GetSetting(key);
+            foreach (var child in GetChildren())
+                child.QueueFree();
+            _tree = null;
         }
         else
         {
-            return @default;
+            foreach (var child in GetChildren())
+                if (child is ObservableTrackerTree t)
+                {
+                    _tree = t;
+                    return;
+                }
         }
+
+        // 2. Build UI
+        _tree = new ObservableTrackerTree();
+
+        var headPanelLayout = new HBoxContainer();
+        AddChild(headPanelLayout);
+
+        var enableAutoReloadToggle = new CheckButton
+            { Text = "AutoReload", TooltipText = "Reload automatically every 2s." };
+        var enableTrackingToggle = new CheckButton { Text = "Tracking", TooltipText = "Enable R3 Tracking." };
+        var enableStackTraceToggle = new CheckButton
+            { Text = "StackTrace", TooltipText = "Capture StackTrace (High Cost)." };
+        var hideOperatorsToggle = new CheckButton { Text = "Hide Ops", TooltipText = "Hide intermediate operators." };
+        var simpleTraceToggle = new CheckButton
+            { Text = "Simple Trace", TooltipText = "Hide Godot/R3/System internal calls." };
+
+        var reloadButton = new Button { Text = "Refresh" };
+        var GCButton = new Button { Text = "GC" };
+
+        var settings = EditorInterface.Singleton.GetEditorSettings();
+
+        // Bind Events & Settings
+        enableAutoReloadToggle.ButtonPressed =
+            _enableAutoReload = GetSettingOrDefault(settings, EnableAutoReloadKey, false).AsBool();
+        enableAutoReloadToggle.Toggled += t =>
+        {
+            settings.SetSetting(EnableAutoReloadKey, t);
+            _enableAutoReload = t;
+        };
+
+        enableTrackingToggle.ButtonPressed =
+            _enableTracking = GetSettingOrDefault(settings, EnableTrackingKey, false).AsBool();
+        enableTrackingToggle.Toggled += t =>
+        {
+            settings.SetSetting(EnableTrackingKey, t);
+            _enableTracking = t;
+            _debuggerPlugin?.SetEnableStates(SessionId, _enableTracking, _enableStackTrace);
+        };
+
+        enableStackTraceToggle.ButtonPressed =
+            _enableStackTrace = GetSettingOrDefault(settings, EnableStackTraceKey, false).AsBool();
+        enableStackTraceToggle.Toggled += t =>
+        {
+            settings.SetSetting(EnableStackTraceKey, t);
+            _enableStackTrace = t;
+            _debuggerPlugin?.SetEnableStates(SessionId, _enableTracking, _enableStackTrace);
+        };
+
+        hideOperatorsToggle.ButtonPressed =
+            _hideOperators = GetSettingOrDefault(settings, HideOperatorsKey, true).AsBool();
+        _tree.SetHideOperators(_hideOperators);
+        hideOperatorsToggle.Toggled += t =>
+        {
+            settings.SetSetting(HideOperatorsKey, t);
+            _hideOperators = t;
+            if (IsInstanceValid(_tree))
+                _tree.SetHideOperators(_hideOperators);
+        };
+
+        simpleTraceToggle.ButtonPressed = _simpleTrace = GetSettingOrDefault(settings, SimpleTraceKey, true).AsBool();
+        _tree.SetSimpleTrace(_simpleTrace);
+        simpleTraceToggle.Toggled += t =>
+        {
+            settings.SetSetting(SimpleTraceKey, t);
+            _simpleTrace = t;
+            if (IsInstanceValid(_tree))
+                _tree.SetSimpleTrace(_simpleTrace);
+        };
+
+        reloadButton.Pressed += () => _debuggerPlugin?.UpdateTrackingStates(SessionId, true);
+        GCButton.Pressed += () => _debuggerPlugin?.InvokeGCCollect(SessionId);
+
+        headPanelLayout.AddChild(enableAutoReloadToggle);
+        headPanelLayout.AddChild(enableTrackingToggle);
+        headPanelLayout.AddChild(enableStackTraceToggle);
+        headPanelLayout.AddChild(hideOperatorsToggle);
+        headPanelLayout.AddChild(simpleTraceToggle);
+
+        headPanelLayout.AddChild(new Control { SizeFlagsHorizontal = SizeFlags.Expand });
+        headPanelLayout.AddChild(reloadButton);
+        headPanelLayout.AddChild(GCButton);
+
+        AddChild(_tree);
+    }
+
+    public override void _ExitTree()
+    {
+        _debuggerPlugin = null;
+    }
+
+    private static Variant GetSettingOrDefault(EditorSettings settings, string key, Variant @default)
+    {
+        if (settings.HasSetting(key))
+            return settings.GetSetting(key);
+        return @default;
     }
 }
 #endif

--- a/src/R3.Godot/addons/R3.Godot/ObservableTrackerTree.cs
+++ b/src/R3.Godot/addons/R3.Godot/ObservableTrackerTree.cs
@@ -1,67 +1,244 @@
 ﻿#if TOOLS
 #nullable enable
 
-using Godot;
 using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Godot;
 
 namespace R3;
 
 [Tool]
 public partial class ObservableTrackerTree : Tree
 {
-    ObservableTrackerDebuggerPlugin? debuggerPlugin;
-    int sessionId;
-    public void NotifyOnSessionSetup(ObservableTrackerDebuggerPlugin debuggerPlugin, int sessionId)
+    // Regex for parsing stack trace
+    private static readonly Regex StackTraceRegex =
+        new(@"\s+in\s+(?<path>.+):line\s+(?<line>\d+)", RegexOptions.Compiled);
+
+    private static readonly string[] OperatorKeywords = new[]
     {
-        this.debuggerPlugin = debuggerPlugin;
-        this.sessionId = sessionId;
-        debuggerPlugin!.RegisterReceivedActiveTasks(sessionId, Reload);
-        Clear();
-    }
+        "Where", "Select", "Take", "Skip", "Do",
+        "Throttle", "Debounce", "Delay", "Sample",
+        "CombineLatest", "Merge", "Zip", "Switch", "Amb",
+        "Distinct", "ObserveOn", "SubscribeOn", "Synchronize",
+        "Repeat", "Retry", "Catch", "Timeout", "IgnoreElements",
+        "Materialize", "Dematerialize", "TimeInterval", "Timestamp",
+        "Chunk", "Buffer", "Window", "Pairwise", "Scan"
+    };
+
+    private ObservableTrackerDebuggerPlugin? _debuggerPlugin;
+    private bool _hideOperators;
+    private IEnumerable<TrackingState>? _lastStates;
+
+    private string _projectPath = "";
+    private int _sessionId;
+    private bool _simpleTrace = true;
 
     public override void _Ready()
     {
+        // Normalize path for cross-platform compatibility
+        var globalPath = ProjectSettings.GlobalizePath("res://");
+        _projectPath = globalPath.Replace('\\', '/').TrimEnd('/');
+
         AllowReselect = false;
         Columns = 3;
         ColumnTitlesVisible = true;
+
         SetColumnTitle(0, "Type");
-        SetColumnTitle(1, "Elapsed");
+        SetColumnTitle(1, "Created At");
         SetColumnTitle(2, "StackTrace");
+
         SetColumnExpand(0, true);
         SetColumnExpand(1, true);
         SetColumnExpand(2, true);
-        SetColumnExpandRatio(0, 3);
-        SetColumnExpandRatio(1, 1);
+
+        SetColumnExpandRatio(0, 4);
+        SetColumnExpandRatio(1, 2);
         SetColumnExpandRatio(2, 6);
+
         SetColumnClipContent(0, true);
         SetColumnClipContent(1, true);
         SetColumnClipContent(2, true);
+
         HideRoot = true;
         SizeFlagsVertical = SizeFlags.ExpandFill;
+
+        ItemActivated += OnItemActivated;
+    }
+
+    private void OnItemActivated()
+    {
+        var item = GetSelected();
+        if (item == null)
+            return;
+
+        var traceText = item.GetText(2);
+        if (string.IsNullOrWhiteSpace(traceText))
+            return;
+
+        var lines = traceText.Split('\n');
+        foreach (var line in lines)
+        {
+            var match = StackTraceRegex.Match(line);
+            if (match.Success)
+            {
+                var absPath = match.Groups["path"].Value.Trim();
+                if (int.TryParse(match.Groups["line"].Value, out var lineNumber))
+                {
+                    JumpToScript(absPath, lineNumber);
+                    return;
+                }
+            }
+        }
+    }
+
+    private void JumpToScript(string absolutePath, int lineNumber)
+    {
+        var resPath = ProjectSettings.LocalizePath(absolutePath);
+
+        if (!FileAccess.FileExists(resPath))
+        {
+            if (!FileAccess.FileExists(absolutePath))
+            {
+                GD.PrintErr($"[R3 Tracker] Cannot find script file: {resPath}");
+                return;
+            }
+
+            resPath = absolutePath;
+        }
+
+        var script = GD.Load<Script>(resPath);
+        if (script != null)
+            EditorInterface.Singleton.EditScript(script, lineNumber);
+    }
+
+    public void NotifyOnSessionSetup(ObservableTrackerDebuggerPlugin debuggerPlugin, int sessionId)
+    {
+        _debuggerPlugin = debuggerPlugin;
+        _sessionId = sessionId;
+        debuggerPlugin.RegisterReceivedActiveTasks(sessionId, OnReceivedActiveTasks);
+        ClearContent();
     }
 
     public override void _ExitTree()
     {
-        debuggerPlugin!.UnregisterReceivedActiveTasks(sessionId, Reload);
+        _debuggerPlugin?.UnregisterReceivedActiveTasks(_sessionId, OnReceivedActiveTasks);
     }
 
-    public void Reload(IEnumerable<TrackingState> states)
+    public void ClearContent()
     {
         Clear();
-        TreeItem root = CreateItem();
-        foreach(TrackingState state in states)
+        _lastStates = null;
+    }
+
+    public void SetHideOperators(bool hide)
+    {
+        _hideOperators = hide;
+        if (_lastStates != null)
+            RefreshTree(_lastStates);
+    }
+
+    public void SetSimpleTrace(bool simple)
+    {
+        _simpleTrace = simple;
+        if (_lastStates != null)
+            RefreshTree(_lastStates);
+    }
+
+    private void OnReceivedActiveTasks(IEnumerable<TrackingState> states)
+    {
+        _lastStates = states;
+        RefreshTree(states);
+    }
+
+    private void RefreshTree(IEnumerable<TrackingState> states)
+    {
+        Clear();
+        var root = CreateItem();
+
+        var count = 0;
+        const int MaxItems = 1000;
+
+        foreach (var state in states)
         {
-            TreeItem row = CreateItem(root);
-            var now = DateTime.Now;
-            // Type
+            if (count >= MaxItems)
+                break;
+
+            if (_hideOperators)
+            {
+                var isOperator = OperatorKeywords.Any(keyword => state.FormattedType.Contains(keyword));
+                var isReactiveProperty = state.FormattedType.Contains("ReactiveProperty");
+
+                if (isOperator && !isReactiveProperty)
+                    continue;
+            }
+
+            count++;
+            var row = CreateItem(root);
+
             row.SetText(0, state.FormattedType);
-            // Elapsed
-            row.SetText(1, (now - state.AddTime).TotalSeconds.ToString("00.00"));
-            // StackTrace
-            row.SetText(2, state.StackTrace);
-        };
+            row.SetTooltipText(0, state.FormattedType);
+
+            // Time Display
+            var localTime = state.AddTime.ToLocalTime();
+            row.SetText(1, localTime.ToString("HH:mm:ss.fff"));
+
+            var elapsed = DateTime.Now - localTime;
+            row.SetTooltipText(1, $"Created at: {localTime}\nElapsed: {elapsed.TotalSeconds:0.00}s ago");
+
+            var displayTrace = state.StackTrace;
+            if (_simpleTrace)
+                displayTrace = FilterStackTrace(state.StackTrace);
+
+            if (string.IsNullOrWhiteSpace(displayTrace) && !string.IsNullOrWhiteSpace(state.StackTrace))
+                displayTrace = state.StackTrace.Split('\n').FirstOrDefault() ?? "";
+
+            row.SetText(2, displayTrace);
+            row.SetTooltipText(2, state.StackTrace + "\n\n(Double-click to jump to source)");
+        }
+
+        if (states.Count() > MaxItems)
+        {
+            var warning = CreateItem(root);
+            warning.SetText(0, $"... {states.Count() - MaxItems} more items hidden ...");
+            warning.SetSelectable(0, false);
+            warning.SetCustomColor(0, new Color(1, 1, 1, 0.5f));
+        }
+    }
+
+    private string FilterStackTrace(string rawTrace)
+    {
+        if (string.IsNullOrEmpty(rawTrace))
+            return "";
+
+        var sb = new StringBuilder();
+        var lines = rawTrace.Split('\n');
+
+        foreach (var line in lines)
+        {
+            var l = line.Trim();
+
+            // Normalize slashes for cross-platform matching
+            var normalizedLine = l.Replace('\\', '/');
+
+            if (normalizedLine.IndexOf(_projectPath, StringComparison.OrdinalIgnoreCase) < 0)
+                continue;
+
+            // Filter Godot & R3 internal calls
+            if (l.Contains(".InvokeGodotClassMethod") ||
+                l.Contains(".HasGodotClassMethod") ||
+                l.Contains(".RestoreGodotObjectData") ||
+                l.Contains(".SaveGodotObjectData") ||
+                l.Contains("System.Reactive") ||
+                l.Contains("R3.Observable"))
+                continue;
+
+            sb.AppendLine(l);
+        }
+
+        return sb.ToString().Trim();
     }
 }
 #endif


### PR DESCRIPTION
This PR resolves a critical `NullReferenceException` that caused the `Observable Tracker` to fail immediately upon startup/enabling https://github.com/Cysharp/R3/issues/357 ; https://github.com/Cysharp/R3/issues/334. It also significantly upgrades the tracker with new filtering capabilities and navigation support.

> **Note:** These changes have been tested on **Godot 4.5.1**.

### 🐛 Fixes
*   **Fixed Startup & Hot Reload Instability:** Resolved the `NullReferenceException` that occurred when enabling the plugin or starting a session. The Tracker now initializes correctly and remains stable across Assembly Reloads (Hot Reload).
*   **Fixed Ghost Instances:** Implemented a check to prevent duplicate `DebuggerPlugin` instances from accumulating and spamming logs.

### ✨ New Features
*   **Toggle: Hide Ops:** Added a checkbox to filter out intermediate operators (e.g., `Where`, `Select`), keeping only `ReactiveProperty` and `Subscribe` events for a cleaner view.
*   **Toggle: Simple Trace:** Added a checkbox to hide internal stack frames from Godot, R3, and System.Reactive, allowing the view to focus solely on user scripts.
*   **Jump to Source:** Double-clicking on the `StackTrace` column now automatically opens the specific script file and line number in the external editor.

### 🎨 Changes
*   **Column Update:** Changed the **"Elapsed"** column (relative duration) to **"Created At"** (absolute local time) to make it easier to correlate events with console logs.
*   **Performance:** Added a maximum item limit (1000 items) to the list to prevent editor freezing when tracking high-frequency observables.