### PR TITLE
fix: resolve TreeView deprecation in Unity 6.2+

### DIFF
--- a/src/R3.Unity/Assets/R3.Unity/Editor/ObservableTrackerTreeView.cs
+++ b/src/R3.Unity/Assets/R3.Unity/Editor/ObservableTrackerTreeView.cs
@@ -8,6 +8,11 @@ using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
+#if UNITY_6000_2_OR_NEWER
+using TreeView = UnityEditor.IMGUI.Controls.TreeView<int>;
+using TreeViewItem = UnityEditor.IMGUI.Controls.TreeViewItem<int>;
+using TreeViewState = UnityEditor.IMGUI.Controls.TreeViewState<int>;
+#endif
 
 namespace R3.Unity.Editor
 {
@@ -170,4 +175,3 @@ namespace R3.Unity.Editor
     }
 
 }
-


### PR DESCRIPTION
## Description

Unity 6 (6000.2) has deprecated the non-generic `TreeView`, `TreeViewItem`, and `TreeViewState` classes in `UnityEditor.IMGUI.Controls`.

*  **Unity 6000.2+**: Triggers obsolete warnings (**CS0618**).
*  **Unity 6000.5+**: Triggers obsolete compiler errors (**CS0619**).

### Solution

Introduced type aliasing for these classes to their generic counterparts (`TreeView<int>`, etc.) using the `#if UNITY_6000_2_OR_NEWER` preprocessor directive.

* **Removes deprecation warnings** in Unity 6000.2 and later.
* **Fixes build errors** in Unity 6000.5 and later.