### PR TITLE
Fix: ThrottleFirstLastFrame emits default(T) after a trailing value was published

### DIFF
--- a/src/R3/Operators/ThrottleFirstLastFrame.cs
+++ b/src/R3/Operators/ThrottleFirstLastFrame.cs
@@ -78,6 +78,7 @@ internal sealed class ThrottleFirstLastFrame<T>(Observable<T> source, int frameC
                     if (hasValue)
                     {
                         observer.OnNext(lastValue!);
+                        hasValue = false;
                         lastValue = default;
                     }
                     running = false;

--- a/tests/R3.Tests/OperatorTests/ThrottleFirstLastTest.cs
+++ b/tests/R3.Tests/OperatorTests/ThrottleFirstLastTest.cs
@@ -180,4 +180,30 @@ public class ThrottleFirstLastTest
         list.AssertEqual([1, 10000, 2, 200, 3]);
         list.AssertIsCompleted();
     }
+
+    [Fact]
+    public void ThrottleFirstLastFrame_HasValueIsResetWhenWindowCloses()
+    {
+        var frameProvider = new FakeFrameProvider();
+
+        var publisher = new Subject<int>();
+        var list = publisher.ThrottleFirstLastFrame(3, frameProvider).ToLiveList();
+
+        publisher.OnNext(1);
+        list.AssertEqual([1]);
+        publisher.OnNext(2);
+        list.AssertEqual([1]);
+
+        frameProvider.Advance(3);
+        list.AssertEqual([1, 2]);
+
+        publisher.OnNext(3);
+        list.AssertEqual([1, 2, 3]);
+
+        frameProvider.Advance(3);
+        list.AssertEqual([1, 2, 3]);
+
+        publisher.OnCompleted();
+        list.AssertIsCompleted();
+    }
 }


### PR DESCRIPTION
  _ThrottleFirstLastFrame.MoveNext clears lastValue on window close but does not reset hasValue, unlike the TimeSpan-based _ThrottleFirstLast variants which reset both. Once a  window has published a trailing value, hasValue stays true forever, so every subsequent window that received only one value re-emits the already-cleared lastValue — i.e. default(T) — when it closes.

```
  var frameProvider = new FakeFrameProvider();
  var subject = new Subject<int>();
  var results = new List<int>();

  subject.ThrottleFirstLastFrame(5, frameProvider).Subscribe(results.Add);

  subject.OnNext(1);          // opens window, emits 1                                                                                                                           
  subject.OnNext(2);          // stored as trailing value                                                                                                                        
  frameProvider.Advance(5);   // window closes, emits 2 (OK)                                                                                                                     

  subject.OnNext(3);          // opens a new window, emits 3                                                                                                                     
  frameProvider.Advance(5);   // window closes, emits 0 = default(int)                                                                                                           

  // results: [1, 2, 3, 0] — expected [1, 2, 3] 
```                                                                                                                                 

  This PR resets hasValue on window close, matching the TimeSpan-based implementation, and adds a regression test.
> The added test fails on current main with [1, 2, 3, 0] (an extra default(int) emission) and passes with this fix.